### PR TITLE
Fix: Core Moves Sheet technical errors (Issue #10)

### DIFF
--- a/build/docs-v2/core_moves_sheet.md
+++ b/build/docs-v2/core_moves_sheet.md
@@ -97,7 +97,7 @@ The GM will respond to what you notice with complications, opportunities, or req
 
 ## WHEN DO YOU ROLL?
 
-Roll 4 Fate dice (4dF: each shows +, 0, or -). Add your relevant stat (+0 to +4). Compare to:
+Roll 4 Fate dice (4dF: each shows +, 0, or -). Add your relevant stat (+0 to +3). Compare to:
 - **Difficulty** (set by GM) for unopposed actions
 - **Opposing roll** for contested actions
 
@@ -176,6 +176,12 @@ Used for: Chases, hacking runs, prolonged combat, social pressure.
 - Each exchange is an attack/counter
 - First to fill Meat stress or take consequences is taken out
 - Describe how each exchange looks in the fiction
+
+**Stress Track Targeting**:
+- Physical violence (Body/Reflexes) → Meat stress
+- Digital attacks/ICE (Code) → Systems stress
+- Social pressure/intimidation (Cool) → Nerves stress
+- Environmental hazards → GM chooses most appropriate track
 
 ---
 
@@ -276,7 +282,12 @@ You have three stress tracks:
 - **Moderate Consequence** (absorbs 4 shifts): Requires attention to clear (medical, repair, rest)
 - **Severe Consequence** (absorbs 6 shifts): Permanent until bought off with advancement
 
-You have **one of each type** per stress track (3 total per type).
+You have **one consequence slot of each severity (mild/moderate/severe) for each stress track**:
+- 3 Mild consequences (one for Meat, one for Nerves, one for Systems)
+- 3 Moderate consequences (one for Meat, one for Nerves, one for Systems)
+- 3 Severe consequences (one for Meat, one for Nerves, one for Systems)
+
+**Total: 9 consequence slots**
 
 **Name the consequence** to match the stress track and how you got hit:
 - Meat: *Cracked Ribs*, *Bullet Wound*, *Concussion*


### PR DESCRIPTION
## Summary

Fixes 3 critical technical errors identified in team review of Core Moves Sheet. These corrections ensure mechanical accuracy and eliminate ambiguity in core game systems.

## Changes

### 1. Fixed Stat Cap (Line 100)
**Before**: `+0 to +4`  
**After**: `+0 to +3`  
**Rationale**: All playbooks (Infiltrator, Nomad, etc.) cap stats at +3. Inconsistency would allow mechanically unbalanced characters.

### 2. Clarified Consequence Slots (Line 279)
**Before**: Ambiguous "3 total per type"  
**After**: Explicit breakdown of 9 consequence slots:
- 3 Mild (one per track: Meat, Nerves, Systems)
- 3 Moderate (one per track)
- 3 Severe (one per track)

**Rationale**: Players need to know total damage capacity. Previous wording was unclear whether it meant 3 total or 9 total.

### 3. Added Stress Track Targeting (After Line 178)
**New section**: "Stress Track Targeting"
- Physical violence (Body/Reflexes) → Meat stress
- Digital attacks/ICE (Code) → Systems stress
- Social pressure/intimidation (Cool) → Nerves stress
- Environmental hazards → GM chooses appropriate track

**Rationale**: Document defined stress for physical combat but not for other opposition types (hacking, social pressure, etc.). GMs needed clear guidance.

## Testing

- [x] Verified stat cap now matches all playbook examples
- [x] Confirmed consequence calculation is now unambiguous (9 total slots)
- [x] Checked stress targeting covers all core stat types
- [x] Cross-referenced with Infiltrator and Nomad playbooks for consistency

## Related Issues

Closes #10

## Phase

- [x] Phase 1: Finalize RPG Text

## Review Focus

These are objective technical corrections based on team analysis. All three fixes address mechanical inconsistencies or ambiguities that would cause confusion during play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>