### PR TITLE
Add Influencer Solo-Play Kit (Undertow / Reiko Alvarez)

### DIFF
--- a/build/docs-v2/influencer_fronts.md
+++ b/build/docs-v2/influencer_fronts.md
@@ -1,0 +1,320 @@
+# UNDERTOW'S FRONTS
+## Apocalypse World-Style Threat Tracking
+
+*A front isn't waiting for Undertow to slip up on camera. It's already moving — an algorithm optimizing for the wrong kind of attention, a brand-safety review getting less routine by the week, a chat thread getting more precise, a fixer whose client just stopped staying quiet. If she does nothing, all four still advance. The audience doesn't pause the feed for her to catch up.*
+
+---
+
+## WHAT IS A FRONT?
+
+A **front** is a threat with:
+- **Description**: What it is and why it matters
+- **Type**: What kind of threat (Warlord, Landscape, Family, Brutes)
+- **Impulse**: What it wants (its driving force)
+- **Cast**: The NPCs who carry it forward — pulled from the Relationship Map
+- **Countdown Clock**: Steps toward its dark future (usually 8-10 steps)
+- **Stakes**: What happens if it completes
+
+**Key Principle**: Fronts advance *unless stopped*. They don't wait for exposure to be dramatic — they build toward it. None of these fronts is a raid, a firefight, or a break-in. Every one of them is a threat to what Undertow can afford to have seen.
+
+---
+
+## FRONT #1: THE FEED FINDS ITS OWN STORY
+
+**Type**: Warlord (an optimization engine trying to dominate what gets seen — it doesn't need malice, just an incentive)
+
+**Description**: The Feed doesn't know Undertow is smuggling anything. It doesn't know what she's smuggling *means*. It just knows that her dives get rewatched at unusual rates, and unusual rewatch patterns are exactly the signal it's built to chase and amplify. The more the vault dive spikes, the harder the Feed pushes rewatches, reaction-stitches, and frame-by-frame breakdown content — none of which Undertow controls, all of which her own Content Vault archive makes possible.
+
+**Impulse**: *To surface every irregular pattern for maximum engagement, whether or not surfacing it destroys the person underneath.*
+
+**Cast**:
+- THE FEED itself (distributed, non-human, indifferent)
+- Reaction-Stitchers (creators who build content out of dissecting other creators' footage)
+- Undertow's own Content Vault (talent that becomes liability)
+- LOGLINE (whose eventual breakdown video the Feed doesn't distinguish from any other high-engagement content)
+
+**Custom Moves**:
+- When you go live, roll Cool to judge whether the Feed is amplifying you for the reason you think it is
+- When you search your own Content Vault archive, roll Tech — on a miss, the search also surfaces the clip you didn't want found
+- When a stitcher or reaction video calls out something specific about a dive, mark advancement on this countdown
+
+---
+
+### COUNTDOWN: VIRAL ESCALATION (10 steps)
+
+**1-2: QUIET PROMOTION**
+- ☐ **The Feed starts pushing the vault dive to viewers outside Undertow's normal follower base**
+  *Nobody flagged anything. The algorithm just noticed the rewatch rate*
+
+- ☐ **A reaction-stitcher cross-posts a clip from the vault dive with unrelated commentary**
+  *Harmless. Also now permanently discoverable by anyone searching the footage*
+
+**3-5: PATTERN RECOGNITION**
+- ☐ **The Feed's engagement model flags a recurring visual — something item-shaped, present in one frame, gone by the next**
+  *Not a person noticing yet. Just a pattern getting weight in a recommendation model*
+
+- ☐ **A compilation video stitches together "unexplained moments" across several of Undertow's dives**
+  *The creator doesn't know what they're showing. They just know it gets views*
+
+- ☐ **Someone searches Undertow's Content Vault-adjacent public archive for "things that don't add up"**
+  *The search returns exactly what it shouldn't*
+
+**6-8: FRAME BY FRAME**
+- ☐ **A fan-made frame-by-frame breakdown isolates the four seconds from the vault dive**
+  *It's not proof of anything yet. It's a very specific question, asked in public*
+
+- ☐ **The breakdown gets looped, slowed, captioned**
+  *"What is that?" trends in the comments under Undertow's own most recent stream*
+
+- ☐ **Someone asks the question directly in Undertow's live chat, mid-stream**
+  *No deflection is going to make this not have happened, on record, timestamped*
+
+**9-10: THE FEED DECIDES**
+- ☐ **The Feed boosts the breakdown video above Undertow's own latest upload**
+  *Whoever's watching the metrics now sees exactly what the algorithm has decided matters*
+
+- ☐ **THE CLIP BECOMES THE TOP RESULT FOR UNDERTOW'S NAME**
+  *Search her. This is what comes up first. Not the dives. This.*
+
+**Stakes**: If this completes, the algorithm — not a person, not an investigation, just an indifferent optimization engine — does the exposing for everyone. There's no one to negotiate with, deflect, or buy off. It's just math, and the math found her.
+
+---
+
+## FRONT #2: THE REVIEW CYCLE
+
+**Type**: Landscape (this is her sponsorship, and it's eroding one review cycle at a time)
+
+**Description**: Undertow's entire arrangement rests on Meridian Holdings believing the "content partnership" is exactly what it looks like — a valued streamer who's unusually good and unusually lucky. Dara Reyes, Meridian's Brand Safety Lead, runs frame-by-frame sponsor-safety review on every dive before it clears for monetization. It used to be routine. It's getting less routine, because Undertow's numbers keep climbing, which means Meridian's exposure keeps climbing, which means Reyes's review keeps getting more thorough.
+
+**Impulse**: *To find the exact thing Meridian can't be associated with, before a competitor's PR team finds it first.*
+
+**Cast**:
+- DARA REYES (Brand Safety Lead, observant, not yet suspicious of the right thing)
+- MERIDIAN HOLDINGS (corporate entity, risk-averse, protective of its own exposure)
+- Meridian Legal (drafts the paperwork that turns suspicion into consequence)
+- MARA SUND (caught in the middle — Reyes's questions go through her first)
+
+**Custom Moves**:
+- When Meridian requests footage, roll Cool to control what context you provide alongside it
+- When you're on a sponsor call, roll Cool to read what Reyes actually suspects versus what she's saying
+- When brand safety flags a dive for any reason, mark advancement on this countdown
+
+---
+
+### COUNTDOWN: REVIEW CYCLE (10 steps)
+
+**1-3: ROUTINE TIGHTENS**
+- ☐ **Reyes requests raw dive footage for a quarterly audit — previously never asked for raw**
+  *"Standard update to our review process." Maybe true. Maybe not.*
+
+- ☐ **Meridian signs a second sponsor onto Undertow's content**
+  *More money. Also more corporate exposure riding on every dive being exactly what it claims to be*
+
+- ☐ **Reyes flags one dive as "needs producer commentary before clearing"**
+  *First time this has ever happened. Mara has to answer for something she didn't do*
+
+**4-6: ESCALATION**
+- ☐ **Reyes asks Mara Sund directly about a specific timestamp**
+  *Not accusatory. Just precise. Mara has to decide what to say*
+
+- ☐ **Meridian Legal requests "chain of custody" documentation on raw footage**
+  *This is not a request that gets made for a normal sponsorship*
+
+- ☐ **A sponsor renewal meeting gets moved up, unscheduled, no explanation given**
+  *Either routine reshuffling, or someone wants to look closely before signing again*
+
+**7-9: CRITICAL EXPOSURE**
+- ☐ **Reyes requests the uncut masters directly, bypassing Mara**
+  *The one file that was never supposed to leave Mara's hands*
+
+- ☐ **Meridian pauses sponsorship pending "internal review"**
+  *No content goes out under Meridian branding until this resolves. Income stops. Questions don't*
+
+- ☐ **Legal drafts a clause referencing "content irregularities requiring disclosure"**
+  *Someone is building a paper trail. It's not clear yet whether it's protecting Meridian or building a case*
+
+**10: RESOLUTION**
+- ☐ **MERIDIAN DEMANDS ANSWERS**
+  *Full stop. Sponsorship frozen until Undertow explains the footage — or until someone else explains it for her*
+
+**Stakes**: If this completes, Undertow loses her legitimate income, her cover story, and possibly her access to Meridian-adjacent salvage sites — the exact access the whole arrangement with Kest depends on. Corporate exposure doesn't end with an arrest. It ends with a frozen account and a very quiet, very thorough audit of everything she's ever streamed.
+
+---
+
+## FRONT #3: THE SKEPTIC'S THREAD
+
+**Type**: Family (people who could be saved or damned by Undertow's choices — followers who think they know her)
+
+**Description**: Not every one of 1.3 million followers is a fan. Some are auditors. A subset of chat has, over months, been quietly building a cross-referenced, timestamped record of things that don't add up across Undertow's dives — inconsistent depth readings, salvage items that appear on camera and are never mentioned again, a route pattern that matches no public wreck survey. Undertow doesn't know this thread exists yet. It's about to matter whether she does.
+
+**Impulse**: *To force the parasocial audience to become an investigative one — and see what survives that transition.*
+
+**Cast**:
+- LOGLINE (methodical, patient, not hostile — just correct)
+- REEFRAT (day-one superfan, fiercely loyal, will escalate any accusation into a public fight)
+- SUBLINE (technically precise, unknown to Undertow: an ex-Meridian salvage surveyor laid off in the same automation wave that created her)
+
+**Custom Moves**:
+- When you address chat or a specific commenter live, roll Cool to redirect without confirming anything
+- When you check what Logline or Subline has posted publicly, roll Tech or Code to find out how much they actually have
+- When a follower asks the one question live, mark advancement on this countdown
+
+---
+
+### COUNTDOWN: PARASOCIAL TO INVESTIGATIVE (8 steps)
+
+**1-2: INNOCENT STAGE**
+- ☐ **Logline posts a benign technical question about a depth reading that doesn't match the dive site**
+  *No accusation. Just curiosity. The kind that doesn't stop*
+
+- ☐ **Subline replies with suspiciously precise correction**
+  *Too specific for a casual viewer. Undertow doesn't know why yet*
+
+**3-5: AWAKENING STAGE**
+- ☐ **Logline starts a shared, cross-referenced document of dive timestamps against public wreck surveys**
+  *Not public yet. A handful of people in a private channel, comparing notes*
+
+- ☐ **Reefrat finds the document, screenshots it, brings it to Undertow "protectively"**
+  *"Someone's building a case against you. I thought you should know." Now Undertow knows too*
+
+- ☐ **Subline privately messages Undertow, offering to "consult" on future dives**
+  *Help, or a way in? Undertow has no way to know which yet*
+
+**6-7: CRISIS STAGE**
+- ☐ **Logline publishes a partial video essay: "Things That Don't Add Up About Undertow"**
+  *Not proof. A pattern, laid out publicly, inviting other people to look closer*
+
+- ☐ **Reefrat organizes a brigade against Logline's channel**
+  *Loyalty as a weapon. It also guarantees more people see the essay than ever would have otherwise*
+
+**8: RESOLUTION**
+- ☐ **THE THREAD GOES PUBLIC OR GOES QUIET**
+  *Either Logline gets the proof and posts it, or someone — Undertow, Subline, even Reefrat — finds a way to defuse it first. The audience decides whether it was watching a streamer or investigating one.*
+
+**Stakes**: If this completes, Undertow learns whether her audience is a fanbase or a jury. Followers either become protective enough to look away on purpose, or thorough enough to end it. Either way, "1.3 million people who don't really know me" stops being true for at least three of them.
+
+---
+
+## FRONT #4: KEST'S STANDING ORDER
+
+**Type**: Brutes (exposure and violence waiting to happen — a network that was never Undertow's to control)
+
+**Description**: Kest isn't freelance. Kest works for someone, and Undertow has never asked who, because Kest pays on time and has never once been wrong about what a wreck is worth. That arrangement holds right up until Kest's employer decides the risk of an increasingly famous streamer with a standing smuggling order outweighs the value of what she keeps finding — or until whoever else has been watching those same dives puts it together first.
+
+**Impulse**: *To reveal that the arrangement was never as private, or as safe, as it looked from Undertow's side of it.*
+
+**Cast**:
+- KEST (fixer, handler, increasingly specific)
+- [KEST'S CLIENT] (unknown, unnamed by design — the mystery is the pressure)
+- MARA SUND (gets pulled deeper into the arrangement as it gets riskier)
+- A rival fixer or corporate counterintel analog (starts noticing the pattern independently)
+
+**Custom Moves**:
+- When you take one of Kest's tips, roll Cool to gauge whether this one's riskier than the last
+- When you stream a dive with a target buried in it, roll Tech to keep the extraction off camera while everything else stays live
+- When Kest's client makes any kind of direct move, mark advancement on this countdown
+
+---
+
+### COUNTDOWN: NETWORK COLLAPSE (10 steps)
+
+**1-3: DISTANT THUNDER**
+- ☐ **Kest's tips get more specific — an exact bulkhead, an exact container, no more plausible deniability**
+  *This isn't "a fan with insider access" anymore. This is instructions*
+
+- ☐ **An unrelated salvage streamer gets publicly outed for smuggling under sponsor cover**
+  *Different person, same method. Undertow watches it happen to someone else and recognizes every step*
+
+- ☐ **Kest misses a scheduled handoff window for the first time**
+  *Could be nothing. Could be the first sign something upstream broke*
+
+**4-6: CLOSING CIRCLE**
+- ☐ **Kest's client changes the ask — something that requires Undertow to actively lie on stream, not just omit**
+  *The gap between "streaming version" and "real version" just got a lot harder to maintain*
+
+- ☐ **The same dive gets claimed by both Front #2 (Meridian's review) and Kest's order**
+  *Brand safety wants this dive clean. Kest's client wants it productive. Those are not the same dive*
+
+- ☐ **Kest asks Undertow to bring Mara into the arrangement directly**
+  *One more person who knows. One more person who could talk*
+
+**7-9: HEAT INTENSIFIES**
+- ☐ **A rival fixer or corporate counterintel analog starts asking about "the buyer paying premium for pre-Rise salvage matching a certain stream's dive pattern"**
+  *Someone outside the arrangement has already connected the dots Undertow thought were hers alone*
+
+- ☐ **Kest goes dark for 48 hours**
+  *Operational security, or something worse. No way to tell from Undertow's side*
+
+- ☐ **[KEST'S CLIENT] contacts Undertow directly for the first time, bypassing Kest entirely**
+  *The middleman just got cut out. That's rarely good news for the middleman, or for whoever's left holding the arrangement*
+
+**10: ENDGAME**
+- ☐ **FORCED CHOICE: BURN THE ARRANGEMENT LIVE, OR LET THE CLIENT DICTATE THE NEXT DIVE**
+  *No more quiet exits. Undertow either ends this on her own terms, on camera, in front of everyone — or finds out exactly how much control she's already lost*
+
+**Stakes**: If this completes without intervention, Undertow's smuggling arrangement is exposed, Kest is burned (or worse), and whoever [KEST'S CLIENT] turns out to be gets to decide what happens to everyone who was ever downstream of the vault dive — including her.
+
+---
+
+## HOW TO USE FRONTS
+
+### Before Each Session:
+**Advance at least one front by 1-2 steps** based on:
+- Time passage (if the PC does nothing, fronts advance)
+- PC actions (sometimes you stop advancement, sometimes you accelerate it)
+- GM instinct (when the pressure feels right, advance toward crisis)
+
+### During Play:
+**Telegraph advancement**: Don't surprise the player with countdown progression
+- Show NPC moves that demonstrate front movement
+- Describe metrics, comments, and DMs that reflect escalation
+- Let the player see the clock ticking in real numbers — view counts, follower deltas, sponsor emails
+
+**Allow intervention**: The PC can slow, stop, or reverse fronts
+- A smart stream might push a front back several steps
+- A careless one might accelerate it live, in front of everyone
+- Ignoring it guarantees advancement
+
+### Between Sessions:
+**Adjust based on fiction**: If the PC fully resolves a front, cross it out
+**Add new fronts**: When one resolves, it often reveals a bigger threat behind it
+**Intersect fronts**: Let them collide for maximum pressure
+
+---
+
+## FRONT INTERSECTION EXAMPLES
+
+**Feed + Review Cycle**: The Feed's algorithmic push puts the exact clip Dara Reyes doesn't want seen directly in front of Meridian's own legal team, before Reyes ever gets the chance to bury it quietly
+
+**Skeptic + Standing Order**: Subline's insider expertise doesn't just spot survey fraud — it recognizes Kest's operational pattern, because Subline used to write the surveys Kest's tips are based on
+
+**Review Cycle + Standing Order**: The same dive gets claimed by both fronts at once — Meridian needs it clean, Kest needs it productive, and Undertow has to choose which lie to tell on camera
+
+**Feed + Skeptic**: The Feed boosts Logline's breakdown video for the exact same reason it boosted the original vault dive — engagement doesn't distinguish between a fan and an investigator
+
+---
+
+## TRACKING ADVANCEMENT
+
+Keep a simple session log:
+```
+SESSION 1:
+- Front #1 (The Feed): Advanced to step 2 (stitcher cross-post)
+- Front #2 (Review Cycle): Advanced to step 1 (raw footage requested)
+- Front #3 (Skeptic's Thread): No advancement
+- Front #4 (Standing Order): Advanced to step 1 (tips get specific)
+
+SESSION 2:
+- Front #1: Advanced to step 4 (pattern flagged by the model)
+- Front #2: Advanced to step 3 (Mara questioned)
+- Front #3: Advanced to step 2 (Subline's precise reply)
+- Front #4: Advanced to step 3 (handoff missed)
+```
+
+**Pattern Emerges**: Fronts 1 and 2 are accelerating together — the algorithm and the sponsor are converging on the same footage from different directions. Front 3 is building quietly. Front 4 just had its first real warning sign.
+
+---
+
+*"Fronts are the audience in motion. They don't wait for the streamer to catch up. They have momentum, metrics, an audience of their own. Your job isn't to stop all of them. Your job is to choose which ones matter most — and accept what happens to the ones you let run."*
+
+**USE FRONTS TO CREATE PRESSURE, NOT TO PUNISH THE PLAYER**

--- a/build/docs-v2/influencer_phase_trio.md
+++ b/build/docs-v2/influencer_phase_trio.md
@@ -1,0 +1,218 @@
+# PHASE TRIO: UNDERTOW
+## FATE-Style Phase Generation for Aspects and Relationships
+
+*The Infiltrator survives by being unseen — three identities, one truth, buried deep. The Influencer survives by being unmissable. Same city, same corps, same total surveillance state. Opposite strategy: don't hide from the cameras — become the camera. Put everything on the feed. Bury the one true thing under everything else that's true.*
+
+*This document walks through Phase Trio for **Reiko Alvarez**, streaming as **UNDERTOW** — a complete, ready-to-play worked example. Use her answers as a model, then run the same questions for your own Influencer.*
+
+---
+
+## HOW PHASE TRIO WORKS
+
+**The Influencer only needs three aspects — no crew relationship web to build, just the person underneath the persona:**
+
+1. **Phase One (The Origin)**: What put you in front of the camera, and what you're really using it for → **HIGH CONCEPT**
+2. **Phase Two (The Crossing)**: The one person off-camera who knows what the feed doesn't show → **CONNECTION**
+3. **Phase Three (The Trouble)**: What the cameras can't be allowed to catch → **TROUBLE**
+
+**Result**: Three aspects that define your character, one loaded relationship, and a countdown clock built into your own popularity.
+
+---
+
+## PHASE ONE: UNDERTOW'S ORIGIN STORY
+
+### THE QUESTIONS
+
+**What put a camera in your hands?**
+- Reiko Alvarez was a licensed salvage tech, contracted to Meridian Holdings' wreck-decommissioning division — cracking open drowned pre-Rise towers before they got scrapped for parts
+- Meridian automated half the division to cut headcount. Reiko wasn't cut — she was offered a "content partnership" instead. Same dives. No union. No hazard pay. A hashtag.
+- She started streaming solo dives on her own gear, on her own time, to prove she didn't need them
+
+**What skill made people stop scrolling?**
+- She's fast and unbothered inside dead corporate architecture — reading condemned systems, cracking sealed doors, narrating the whole thing like it's nothing
+- Three years of decommissioning work means she knows exactly which wrecks are "empty" and which ones the surveys lied about
+- The stream that made her: a live dive into a sealed vault in a sunken Sidereal-era tower, cracking eleven-year-old corporate security on camera, viewers screaming into chat the whole time
+
+**Who turned your feed into a business?**
+- Meridian saw the vault stream's numbers and called the next morning — sponsorship, not employment, this time on their terms
+- Two more sponsors followed once the follower count crossed a million: gear, credits, "creative input" nobody asked for
+- Somewhere in that same week, a second call came in — not a sponsor. Someone who'd also watched the vault stream, and wanted to know exactly what else had been inside it
+
+**What are you actually broadcasting?**
+- Not everything in the vault made it into the video. One item never got shown, never got named, and got quietly delivered somewhere else entirely
+- The caller — a fixer going by **Kest** — pays well for it to happen again
+- So it happens again. Every "spontaneous" dive that goes viral now has a target buried inside it. The stream is real. The excitement is real. One item per haul isn't hers to keep, and nobody watching — sponsors included — can tell which one that is
+
+---
+
+### PHASE ONE STORY
+
+**Title**: *"The Vault Nobody Finished Watching"*
+
+**Summary**: Reiko spent three years cracking open drowned buildings for a corp that valued her enough to automate her out of a paycheck. She kept diving anyway, alone, on stream, because it was the only version of the job where she still got to be good at it in front of anyone who cared. The vault dive was supposed to be a career moment — and it was, just not the one Meridian thinks it was. Somewhere between the sealed door and the highlight reel, she started working for someone else too. Now every viral dive carries two payloads: the one 1.3 million people watch her find, and the one she never shows finding at all.
+
+**Aspect Generated**: **Salvage Streamer Smuggling in Plain Sight of Millions**
+
+*This HIGH CONCEPT captures: the real, hard-won technical skill (she's not faking the dives); the total visibility of her working life; and the one transaction she runs directly through the middle of that visibility — a bet that nobody scrutinizes what they're already watching.*
+
+*Invoke: when the noise of your own popularity is the best cover you have, when your genuine competence sells the lie, when being watched by everyone means being suspected by no one.*
+*Compel: when a sponsor, follower, or moderator asks the one question about the footage you can't answer honestly.*
+
+---
+
+## PHASE TWO: THE CROSSING
+
+### THE SETUP
+
+**You need one person off-camera who's tangled up in what the feed doesn't show.** Choose from:
+
+- The Nomad (boat captain who gets you to the wreck and back)
+- The Fixer (the buyer who turned your best moment into a standing order)
+- The Producer (off-camera specialist who decides what survives the edit)
+
+Ask yourself:
+- How did they find out?
+- What do you do for each other that isn't on any invoice?
+- What happens to you if they ever decide to talk?
+
+---
+
+### OPTION A: CROSSING WITH NOMAD
+
+**Title**: *"Dock Lights Off, Meter Running"*
+
+**What Happened**: The vault dive needed a boat that wouldn't show up on a Meridian shipping log — a route through drowned towers that "responsible" salvage crews don't run. **[NOMAD]** took the job without asking why a sponsored streamer needed an unlisted route. Kept the engine idling the whole dive. Never once glanced at what came up in the bags beyond what made it on camera.
+
+Three dives later, it's a standing arrangement. [NOMAD] gets paid in cash that never touches Reiko's sponsor accounts. Reiko gets a captain who's never curious at the wrong moment.
+
+**The Cost**: [NOMAD]'s boat is on harbor cameras near every one of these dives. If anyone cross-references Reiko's stream timestamps against dock logs, [NOMAD] is the loose thread that unravels everything — and they know it.
+
+**Aspect Generated**: **"[NOMAD] Never Asks What's Really in the Bags"**
+
+*Invoke: when you need transport off the record, or a captain who won't repeat what they've seen.*
+*Compel: when [NOMAD]'s boat gets flagged, or when their silence suddenly has a price.*
+
+---
+
+### OPTION B: CROSSING WITH FIXER
+
+**Title**: *"The Second Call After the Vault"*
+
+**What Happened**: The morning after the vault stream went viral, Meridian called with a sponsorship offer. An hour later, a second call came from someone who'd watched the same footage and noticed something the comments section didn't: one specific item, on screen for four seconds, never mentioned again. **Kest** didn't threaten her. Kest made an offer — for that item, and for whatever came up in dives like it going forward. Reiko said yes before she'd finished deciding to.
+
+Kest doesn't send instructions. Kest sends "sponsor tips" — coordinates for wrecks worth streaming, framed as tips from a fan with insider access. Reiko decides how to get the real prize into frame and out of the story. Kest just collects.
+
+**The Cost**: Kest has the original, unedited vault footage — the version with the item still in frame before Reiko's producer cut around it. As long as Kest is happy, that file stays a bargaining chip instead of evidence.
+
+**Aspect Generated**: **"Kest Turned My Viral Moment Into a Standing Order"**
+
+*Invoke: when you need a buyer, a target, or someone who already knows the real stakes of a dive.*
+*Compel: when Kest calls in a job on Reiko's schedule instead of theirs, or when Kest's patience for "just the streaming version" runs out.*
+
+---
+
+### OPTION C: CROSSING WITH PRODUCER
+
+**Title**: *"The Cut Nobody Notices"*
+
+**What Happened**: Somebody has to turn six hours of raw dive footage into eleven minutes of viral content — and somebody has to decide, shot by shot, what stays out of the final cut. **[PRODUCER]** has done that job since before the vault stream, and has therefore seen every frame Reiko never wanted seen. The first time it happened, [PRODUCER] didn't ask questions, just quietly re-cut the sequence and never mentioned the missing ninety seconds again. Reiko has never confirmed out loud what [PRODUCER] already knows. Neither has [PRODUCER].
+
+**The Cost**: [PRODUCER] holds every uncut master file. That's the only copy of the truth that exists anywhere, and it is entirely outside Reiko's control.
+
+**Aspect Generated**: **"[PRODUCER] Cuts the One Frame That Would End Me"**
+
+*Invoke: when you need something scrubbed from the record before anyone else sees it, or a second pair of eyes who already knows what not to say.*
+*Compel: when [PRODUCER] is pressured, subpoenaed, or simply tempted by what those masters are worth.*
+
+---
+
+### UNDERTOW'S CROSSING (AS PLAYED)
+
+Reiko's sheet uses **Option B**. Kest is the connection that started the whole arrangement, which makes Kest the one relationship that can burn the entire premise down — the most useful hook for a GM, and the clearest throughline from Phase One.
+
+**Aspect Generated**: **"Kest Turned My Viral Moment Into a Standing Order"**
+
+---
+
+## PHASE THREE: TROUBLE
+
+**Every character has a TROUBLE aspect** — the pressure that doesn't go away just because you're good at your job, the complication built into the thing you're best known for.
+
+### THE QUESTIONS
+
+**What threatens the arrangement?**
+- Every dive is filmed by multiple cameras, streamed live, archived forever — including the seconds she's counting on nobody rewatching closely
+- Her own Content Vault talent means there's a perfect, permanent, timestamped record of every dive she's ever done — a resource for her, and a future liability for exactly the same reason
+- Sponsors run analytics on her footage frame-by-frame for brand-safety review; they are, functionally, already looking
+
+**What threatens Reiko personally?**
+- She got into this to prove she didn't need Meridian. She now depends on two employers instead of one, and the second one doesn't do performance reviews — just consequences
+- Her followers think they're watching an honest person do a dangerous job for real. They're right about the dangerous job.
+- She's genuinely proud of the dives. The pride and the smuggling run through the same footage, and she's stopped being able to feel them as separate things
+
+**What can the GM use to complicate her life?**
+- Have a follower notice the one detail nobody was supposed to notice, live, in chat, in real time
+- Have Meridian's brand-safety review flag a dive as "inconsistent with sponsor content" for reasons that have nothing to do with the real problem
+- Put Kest's target and Meridian's PR interests in direct conflict on the same dive
+- Force her to choose, on camera, between finishing the stream as scripted and doing the thing that's actually right
+
+---
+
+### UNDERTOW'S TROUBLE
+
+**Aspect**: **"The Footage Doesn't Lie—Except When It Has To"**
+
+**What This Means**:
+- Everything about Undertow's brand runs on the promise that the stream is real and unedited — that's the entire value proposition, to followers and sponsors alike
+- That promise is true for roughly ninety-nine percent of every dive. The other one percent is the part that matters most
+- Every asset that makes her good at this — the raw footage, the follower trust, the sponsor access, the Content Vault archive — is also a permanent, growing record of the one thing she can't afford anyone to review closely
+- The bigger Undertow gets, the more footage exists, the more people are watching frame-by-frame, and the smaller the margin for error gets. Success and exposure rise on the exact same curve
+
+**Invoke When**:
+- You use the audience's trust in "the feed is always honest" to misdirect them precisely
+- You need people to believe something because they watched it happen with their own eyes
+- You're counting on volume — nobody rewatches six hours of raw dive footage that closely
+
+**Compel When**:
+- Someone asks to see the raw, unedited file
+- A sponsor's brand-safety review flags the wrong four seconds for the wrong reason
+- Kest and Meridian want incompatible things out of the same dive
+- Your own Content Vault talent surfaces the exact clip you needed to stay buried
+
+---
+
+## PUTTING IT ALL TOGETHER
+
+### UNDERTOW'S COMPLETE ASPECTS
+
+**High Concept**: Salvage Streamer Smuggling in Plain Sight of Millions
+**Trouble**: The Footage Doesn't Lie—Except When It Has To
+**Connection**: Kest Turned My Viral Moment Into a Standing Order
+
+**Alternate Free Aspects** (pick one later, or during play, if a fourth is wanted):
+- *"Meridian Thinks They Own the Footage"*
+- *"1.3 Million Followers, Zero of Them Know the Real Me"*
+- *"I Was Good at This Before Anyone Was Watching"*
+- *"Every Dive Site Was Once Someone's Home"*
+
+---
+
+## GM NOTES: USING THE CONNECTION
+
+**Invoke it regularly**:
+- "I check with Kest before taking a dive — is this one of his?"
+- "I ask my producer to confirm what actually made the final cut"
+- "I know Kest's coordinates are never random — I read the tip for what it's really telling me"
+
+**Compel it for drama**:
+- "Kest needs this week's dive to go somewhere Meridian would never approve"
+- "Your producer got a call from Meridian's legal team asking for the uncut masters"
+- "Someone in your comments just asked the one question you can't answer live"
+
+**Between sessions**: Kest gets a face, a history, and demands of their own. Meridian's brand-safety team becomes a recurring pressure, not a one-time complication. Followers stop being an abstract number and start being specific people who notice specific things.
+
+---
+
+*Undertow doesn't hide from the surveillance state. She streams directly into it, on purpose, at scale, and dares anyone to find the one true thing inside everything true she's showing them. That's not the opposite of the Infiltrator's total secrecy. It's the same bet, played from the other side of the camera.*
+
+**NOW YOU HAVE A CHARACTER WITH A BRAND, A DEBT, AND A CLOCK**

--- a/build/docs-v2/influencer_pregen.md
+++ b/build/docs-v2/influencer_pregen.md
@@ -1,0 +1,209 @@
+# REIKO ALVAREZ [UNDERTOW]
+## Salvage Tech + Influencer
+
+*"The dive's real. The excitement's real. Nobody rewatches six hours that closely."*
+
+---
+
+## THE FRAME
+
+**What Meridian Sees**: Reiko Alvarez, ex-decommissioning contractor turned "content partner." Same dives she did on salary, minus the union, minus the hazard pay, plus a hashtag. Compliant. Profitable. Worth the sponsorship line item.
+
+**What 1.3 Million Followers See**: UNDERTOW — fast, funny, fearless inside condemned pre-Rise architecture. Cracks eleven-year-old corporate security live, on camera, and makes it look easy. The most honest thing on their feed, they'd tell you.
+
+**What Only Kest Knows**: One item per haul isn't hers to keep. Every viral dive has a target buried inside it. The stream is real. The excitement is real. That's what makes it work.
+
+*Pick your camera angle. The fiction becomes real when everyone agrees which frame they're watching.*
+
+---
+
+## ASPECTS
+
+**High Concept**: **Salvage Streamer Smuggling in Plain Sight of Millions**
+
+The real, hard-won technical skill. The total visibility of her working life. One transaction run directly through the middle of that visibility — a bet that nobody scrutinizes what they're already watching.
+
+*Invoke*: When the noise of your own popularity is the best cover you have, when your genuine competence sells the lie, when being watched by everyone means being suspected by no one.
+
+*Compel*: When a sponsor, follower, or moderator asks the one question about the footage you can't answer honestly.
+
+**Trouble**: **The Footage Doesn't Lie—Except When It Has To**
+
+Undertow's brand runs on the promise that the stream is real and unedited. True for roughly ninety-nine percent of every dive. The other one percent is the part that matters most. Every asset that makes her good at this — raw footage, follower trust, sponsor access, the Content Vault archive — is also a permanent, growing record of the thing she can't afford anyone to review closely. Success and exposure rise on the same curve.
+
+*Invoke*: When you use the audience's trust in "the feed is always honest" to misdirect them precisely, when you need people to believe something because they watched it with their own eyes, when you're counting on volume — nobody rewatches six hours of raw dive footage that closely.
+
+*Compel*: When someone asks to see the raw, unedited file. When a sponsor's brand-safety review flags the wrong four seconds for the wrong reason. When Kest and Meridian want incompatible things out of the same dive. When her own Content Vault talent surfaces the exact clip she needed to stay buried.
+
+**Connection**: **Kest Turned My Viral Moment Into a Standing Order**
+
+The morning after the vault stream went viral, Meridian called with a sponsorship. An hour later, Kest called too — not a threat, an offer, for the one item that never made the highlight reel, and for whatever comes up in dives like it going forward. Kest sends "sponsor tips" — coordinates dressed up as fan mail. Reiko decides how to get the real prize into frame and out of the story. Kest just collects. And Kest still has the unedited vault footage, the version with the item still in shot.
+
+*Invoke*: When you need a buyer, a target, or someone who already knows the real stakes of a dive.
+
+*Compel*: When Kest calls in a job on Reiko's schedule instead of theirs, or when Kest's patience for "just the streaming version" runs out.
+
+**Alternate Free Aspects** *(pick one later, or during play, if a fourth is wanted)*:
+- *"Meridian Thinks They Own the Footage"*
+- *"1.3 Million Followers, Zero of Them Know the Real Me"*
+- *"I Was Good at This Before Anyone Was Watching"*
+- *"Every Dive Site Was Once Someone's Home"*
+
+---
+
+## STATS
+
+- **Body**: +1
+- **Reflexes**: +1
+- **Code**: +2
+- **Tech**: +3 *(Three years cracking condemned corporate architecture. This is the real part.)*
+- **Cool**: +2 *(Narrating a live dive into a sealed vault like it's nothing, viewers screaming in chat the whole time.)*
+
+---
+
+## STRESS TRACKS
+
+- **Meat**: ▢▢ *(Chromed for the dive work. Absorbs less on the meat side.)*
+- **Nerves**: ▢ *(Performance pressure, no privacy, always one camera short of alone.)*
+- **Systems**: ▢▢▢▢▢▢▢▢ *(Heavily chromed. This is where she breaks.)*
+
+---
+
+## CHROME & AUGMENTATION (Choose 3)
+
+**Streaming Suite** *(REQUIRED — Multi-camera system, live broadcast, AR overlay for viewers)*
+- **Effect**: Stream everything you do. Followers watch in real time. Sponsors see analytics.
+- **Secret Use**: Framing controls the story. What's in frame is real — provably, permanently. What's out of frame never happened, as far as anyone reviewing the footage can prove.
+- **Stress Shift**: +2 Systems, -1 Nerves
+- **Maintenance**: 600 credits/month
+- **When it breaks**: Working without audience feedback. -1 Cool until fixed. Sponsors notice.
+
+**Enhanced Dexterity Package** *(Precision tools built into hands, for detailed work on camera)*
+- **Effect**: +2 to Tech when viewers are watching you work.
+- **Secret Use**: The same hands that make cracking a sealed vault door look effortless on stream are the hands that palm the one item that never makes the highlight reel.
+- **Stress Shift**: +2 Systems, -1 Meat
+- **Maintenance**: 500 credits/month
+- **When it breaks**: Hands malfunction on camera. Public failure. Take 2 Nerves stress from embarrassment.
+
+**Social Analysis Suite** *(Read your audience in real time. Know what they want to see.)*
+- **Effect**: +2 to Cool reading audience reactions, adjusting performance.
+- **Secret Use**: The same real-time read that tells her when chat wants more spectacle also tells her, instantly, when chat is getting too close to the one detail she can't let them notice.
+- **Stress Shift**: +1 Systems, -1 Nerves
+- **Maintenance**: 400 credits/month
+- **When it breaks**: Performing blind. Can't gauge reactions.
+
+**CHROME TOTAL**: +5 Systems, -1 Meat, -2 Nerves
+**FINAL TRACKS**: Meat ▢▢, Nerves ▢, Systems ▢▢▢▢▢▢▢▢
+
+---
+
+## TALENTS (Choose 2)
+
+**Content Vault** (2 points)
+- **Effect**: You've recorded everything. Once per session, review past streams for perfect recall of any scene you've streamed. You have video evidence of what happened — if you want to release it.
+- **Note**: This is also the exact liability her Trouble names. Same archive, same footage — cuts whichever way the person asking has leverage.
+
+**Performance Mode** (4 points)
+- **Effect**: When working with audience watching, +2 to Tech or Cool (your choice). Once per session, call for your followers' help — they crowdsource a solution, find information, or provide a distraction. GM determines what they can do.
+- **Note**: The vault crack that took three years of Meridian training also happens to look incredible on camera. That's not a coincidence she has to fake.
+
+---
+
+## THE INFLUENCER MOVE: THE STREAM
+
+Once per session, when Reiko activates the stream for a critical moment, she can invoke her audience:
+
+**"1.3 million people are watching this right now."**
+
+Everyone in the scene knows they're being watched. While active: +2 to Cool, evidence exists of everything that happens, she can't back down without losing followers, complications come from being public.
+
+After the scene, roll Cool:
+- **Success**: Goes viral. Reputation grows. Gain a Fate point.
+- **Failure**: Controversy. Comments are brutal. A sponsor wants to talk.
+
+---
+
+## GEAR
+
+**On the Sponsor Invoice** *(monitored, logged, analyzed)*:
+- Helmet-and-drysuit-integrated multi-cam array (via Streaming Suite), rated for wreck-depth pressure
+- Redundant waterproof backup drives, timestamped and cloud-synced — mostly
+- Sponsor packages: Meridian Holdings dive gear, plus two more unnamed sponsor packages (gear, credits, "creative input" nobody asked for)
+- Branded drysuit line, always camera-ready sixty feet down
+- Waterproof emergency makeup kit, for the surface interview after the dive
+- 2,500 credits
+
+**Off the Invoice** *(nobody's asked about these yet)*:
+- One backup drive that never syncs to the sponsor cloud — raw, unedited dive footage, the only copy besides Kest's
+- Kest's coordinates, delivered as "fan tips," logged nowhere official
+- Three years of Meridian decommissioning survey data she was never supposed to keep — she knows exactly which "empty" wrecks the surveys lied about
+
+---
+
+## FATE POINTS
+
+Start each session with **3** (Refresh 3). Carries over between sessions — never less than 3 at session start. NPCs (Kest, Meridian's brand-safety reviewers, sponsors) don't refresh; this economy is Reiko's alone.
+
+---
+
+## ROLEPLAYING NOTES
+
+**Voice**: Unbothered and narrating, even when her pulse says otherwise. The dive-commentary cadence doesn't switch off just because the cameras did.
+
+**Mannerisms**:
+- Talks to chat even when chat isn't there
+- Reads a room the way she reads a wreck survey — for what's been quietly moved
+- Genuinely proud of the technical work; the pride and the smuggling run through the same footage, and she's stopped being able to feel them as separate things
+- Counts cameras before she counts exits
+
+**What She Wants** *(pick at least one)*:
+- Get out from under Kest's standing order without losing the sponsors
+- Prove — to herself, mostly — that Undertow would still be worth watching without the second payload
+- Find out what Kest is actually doing with what she delivers
+- Keep the Content Vault from ever being subpoenaed
+- All of the above (ambitious, possibly fatal)
+
+**What She Fears**:
+- A follower spotting the one detail live, in chat, before she can cut the feed
+- Kest and Meridian wanting incompatible things out of the same dive, on the same day
+- Finding out she's not as good at this as the edited version suggests
+- That the vault footage Kest is sitting on gets released regardless of what she does next
+
+---
+
+## QUICK REFERENCE
+
+**Best At**: Technical work while being watched, making dangerous things look effortless, reading an audience in real time, leveraging sponsor access, getting away with it because everyone's already looking.
+
+**Weak At**: Privacy, turning the performance off, going off-grid, telling her own excitement from the job's excitement, saying no to chat.
+
+**Invoke Aspects**:
+- Using genuine competence as the cover story
+- Counting on volume — nobody rewatches six hours that closely
+- Calling in Kest for a buyer, a target, or someone who already knows the stakes
+
+**Compel Aspects**:
+- Someone asks to see the raw, unedited file
+- Sponsor brand-safety flags the wrong four seconds for the wrong reason
+- Kest calls in a job on her schedule instead of theirs
+- Her own Content Vault surfaces the clip she needed to stay buried
+
+---
+
+*Undertow doesn't hide from the surveillance state. She streams directly into it, on purpose, at scale, and dares anyone to find the one true thing inside everything true she's showing them.*
+
+**READY TO PLAY UNDERTOW**
+
+---
+
+## RULES-CHECK PASS
+
+Verified against `influencer_playbook_v2.md` and `core_moves_sheet.md`:
+
+- **Stats** — Body +1, Reflexes +1, Code +2, Tech +3, Cool +2: matches the Influencer's fixed stat line exactly (this playbook has no point-buy; the array is set). No deviation.
+- **Stress tracks** — Base 3/3/3 per playbook + core moves default. Chrome shifts: Streaming Suite (+2 Sys/-1 Nerves) + Enhanced Dexterity (+2 Sys/-1 Meat) + Social Analysis Suite (+1 Sys/-1 Nerves) = Meat 2, Nerves 1, Systems 8. This lands exactly on the playbook's stated "Typical Influencer Stress Profile" (Meat 1-2, Nerves 1-2, Systems 8). No deviation.
+- **Chrome count** — Exactly 3 chosen, as required ("Choose 3 — Yes, three"), and Streaming Suite is included as the playbook marks it REQUIRED. No deviation.
+- **Fate points** — 3/session, refresh floor of 3, carries between sessions, PC economy per `core_moves_sheet.md`. No deviation.
+- **Aspects** — High Concept, Trouble, and Connection text and invoke/compel notes are unchanged from the finalized Phase Trio document (Option B / Kest crossing, as played). No deviation.
+- **Talents — judgment call**: The Influencer playbook states "Choose 2" but, unlike the Infiltrator ("8-point build"), never states an explicit point budget. Content Vault (2) + Performance Mode (4) = 6 points, matching the playbook's own worked example (Kaida Voss: Performance Mode 4 + Sponsored Access 2 = 6). Content Vault was a hard requirement, not a free choice — the finalized Trouble aspect explicitly references it ("her own Content Vault talent surfaces the exact clip"), so the brief effectively locked that pick. Performance Mode was chosen as the best fit for a solo-play pregen (audience crowdsourcing, +2 while performing) over the sponsor/reputation-focused talents, but that's a content judgment call, not a rules one — any other 2-point talent would be equally rules-legal.
+- **Gear** — All six playbook-required starting gear categories present (streaming rig, backup recording devices, sponsor packages, professional wardrobe, emergency makeup kit, 2,500 credits), reflavored to the salvage-diving premise; nothing added contradicts the playbook. The "Off the Invoice" list is original content-layer flavor (not a mechanical addition) built directly from details already established in the finalized Phase Trio document, not invented.

--- a/build/docs-v2/influencer_quick_reference.md
+++ b/build/docs-v2/influencer_quick_reference.md
@@ -1,0 +1,334 @@
+# UNDERTOW QUICK REFERENCE
+## How All The Pieces Work Together
+
+*You have five artifacts now. Here's how they connect.*
+
+---
+
+## THE ARTIFACTS
+
+1. **Pregen Sheet** - Who Reiko Alvarez is mechanically
+2. **Relationship Map** - Who matters and why (Ron Edwards style)
+3. **Fronts** - What threatens her and when (Apocalypse World style)
+4. **Phase Trio** - How her three aspects came to be (FATE style)
+5. **Solo Session** - How to play her origin story
+
+**Each serves a different purpose. Together they create a complete character.**
+
+---
+
+## HOW TO USE THEM
+
+### FOR CHARACTER GENERATION
+
+**Start with Phase Trio** (Artifact #4)
+- Write Reiko's origin story (Phase One) → generates HIGH CONCEPT
+- Choose the one off-camera crossing that knows what the feed doesn't show (Phase Two) → generates CONNECTION
+- Define what the cameras can't be allowed to catch (Phase Three) → generates TROUBLE
+- Result: three complete aspects, one loaded relationship, and a clock built into her own popularity
+
+**Transfer to the Pregen Sheet** (Artifact #1)
+- Stats are fixed for the Influencer (Body +1, Reflexes +1, Code +2, Tech +3, Cool +2) — no point-buy, just record them
+- Aspects from Phase Trio fill in the High Concept, Trouble, and Connection lines
+- Chrome (choose 3, Streaming Suite required) and talents (choose 2) are picked to fit how you want to play her
+- Gear splits into what's on the sponsor invoice and what isn't
+
+**Build the Relationship Map** (Artifact #2)
+- Place Undertow at the center
+- Add NPCs: Kest, Meridian/Dara Reyes, Mara Sund, The Feed, and the named followers (Reefrat, Logline, Subline)
+- Key each relationship back to one of the three Phase Trio aspects
+- Draw lines showing who wants what from whom, and who has leverage
+
+**Set Up Fronts** (Artifact #3)
+- Four threats: The Feed Finds Its Own Story, The Review Cycle, The Skeptic's Thread, Kest's Standing Order
+- Each has a countdown clock (8-10 steps)
+- Position them at starting steps (see Solo Session for initial positions)
+- These create momentum and pressure without waiting for the player to slip up
+
+---
+
+### FOR SOLO PREQUEL SESSION
+
+**Use the Solo Session Guide** (Artifact #5) as play structure:
+- Five scenes across one evening — a live dive, a comment section, the vault footage, Kest's new ask, and an optional final choice
+- Each scene tests a different aspect of Undertow's character
+- Scenes advance fronts based on choices
+- By the end, the character is established and ready for crew play
+
+**Reference the Pregen Sheet** during play:
+- When rolling dice, use stats
+- When taking stress, mark boxes (Meat, Nerves, Systems)
+- When invoking aspects, spend Fate points
+- When using talents (Content Vault, Performance Mode) or the Stream move, apply the mechanical benefits
+
+**Track Front Advancement** during play:
+- Each scene might advance one or two fronts
+- Mark which steps are completed
+- Pressure escalates naturally — the algorithm, the sponsor, the audience, and the fixer don't pause for anyone
+- Fronts create consequences for choices, not punishments for playing
+
+**Update the Relationship Map** after play:
+- Add new connections revealed
+- Update who has leverage
+- Note loyalty shifts
+- Map shows how the story changed
+
+---
+
+### FOR CREW PLAY
+
+**Pregen Sheet** is your mechanical reference:
+- Stats for rolls
+- Stress for damage
+- Aspects for invoking/compelling
+- Talents and the Stream move for special beats
+
+**Relationship Map** shows connections:
+- Which NPCs matter (Kest, Reyes, Mara, the followers)
+- Where pressure points are
+- Who can help or threaten
+
+**Fronts** create ongoing pressure:
+- GM advances them between sessions
+- They don't wait for the PC to act
+- Create time pressure and stakes
+- Force choices between priorities — Meridian's clean quarterly review versus Kest's standing order, on the same dive
+
+**Phase Trio** supplies the history:
+- The Crossing option not used in the finalized build (Nomad or Producer, whichever wasn't picked) is parked as a road not taken — bring it in if a crew member's playbook fits
+- Established stakes to reference: what put the camera in her hands, who turned the feed into a business, what she's actually broadcasting
+- Story hooks for complications baked into her own popularity
+
+---
+
+## EXAMPLE: USING EVERYTHING IN ONE SESSION
+
+### Setup (Before Play)
+
+**Pregen Sheet**: Reiko's stats and stress available
+**Relationship Map**: Kest, Reyes, Mara, and the three named followers mapped
+**Fronts**: The Feed at step 1, Review Cycle at step 1, Skeptic's Thread at step 1, Standing Order at step 1 — the same baseline positions the Solo Session's own Session Setup uses
+**Phase Trio**: Established that Undertow's Connection is Kest — the fixer who turned her viral moment into a standing order
+
+---
+
+### During Play
+
+**SCENE**: Undertow streams a dive into a sealed pre-Rise vault with a target buried inside
+
+**Pregen Sheet**:
+- Reiko rolls Tech +3 to crack the sealed door on camera
+- Uses the Stream move — "1.3 million people are watching this right now" — for +2 to Cool on the follow-up read
+- Success! The crowd loves it
+
+**Relationship Map**:
+- Undertow reads Kest's latest "sponsor tip" for what it's really telling her
+- Invokes "Kest Turned My Viral Moment Into a Standing Order" to know exactly which item isn't hers to keep
+- Gets it into frame and out of the story without anyone noticing
+
+**Fronts Advancement**:
+- The viral dive advances **The Feed** (unusual rewatch rate, quiet promotion)
+- A clean extraction holds off **The Skeptic's Thread** for now
+- But the item's disappearance advances **Kest's Standing Order** (the tips just got more specific)
+
+**Phase Trio Connection**:
+- Undertow and Kest have an established arrangement — no need to negotiate terms
+- But the GM compels: "Kest wants this dive to go somewhere Meridian would never approve"
+- Reiko accepts the compel, takes a Fate point, and now has to reconcile two employers wanting incompatible things out of the same footage
+
+---
+
+### Result
+
+**All tools working together**:
+- The Pregen Sheet provided the mechanics
+- The Relationship Map showed who to read and who to answer to
+- Front advancement created consequences
+- The Phase Trio history made the arrangement smooth but complicated
+- The story advanced naturally, on camera, in front of everyone
+
+---
+
+## THE INTEGRATION PRINCIPLE
+
+**Each artifact does one thing well**:
+
+**Pregen Sheet** = Mechanical capability (what she CAN do)
+**Relationship Map** = Human connections (who she KNOWS)
+**Fronts** = External pressure (what THREATENS her)
+**Phase Trio** = Established history (why the aspects are TRUE)
+**Solo Session** = Character discovery (who she IS)
+
+**Together** = A complete character ready for play
+
+---
+
+## PREP CHECKLIST
+
+### Before First Session:
+
+**✓ Complete Phase Trio**
+- [ ] Write the origin story (Phase One) → High Concept
+- [ ] Choose the Crossing — Nomad, Fixer, or Producer (Phase Two) → Connection
+- [ ] Define what the cameras can't catch (Phase Three) → Trouble
+
+**✓ Fill the Pregen Sheet**
+- [ ] Transfer aspects from Phase Trio
+- [ ] Choose chrome (3 pieces, Streaming Suite required)
+- [ ] Choose talents (2, budgeted to the playbook's own worked example)
+- [ ] Calculate final stress tracks (base 3/3/3, shifted by chrome)
+- [ ] Select starting gear — sponsor-invoice and off-invoice
+
+**✓ Build the Relationship Map**
+- [ ] Place Undertow at the center
+- [ ] Add core NPCs (Kest, Reyes, Mara, The Feed)
+- [ ] Add the three named followers (Reefrat, Logline, Subline)
+- [ ] Draw relationship lines (who wants what from whom)
+- [ ] Note leverage and tensions, keyed to the three aspects
+
+**✓ Set Front Starting Positions**
+*(matches the Solo Session's own Session Setup — every front starts at Step 1, meaning nothing has happened yet)*
+- [ ] The Feed Finds Its Own Story: Step 1 (nothing pushed yet, but the vault dive is out there)
+- [ ] The Review Cycle: Step 1 (Reyes's process is still routine — for now)
+- [ ] The Skeptic's Thread: Step 1 (Logline hasn't posted anything yet)
+- [ ] Kest's Standing Order: Step 1 (tips are still framed as "fan mail")
+
+**✓ Read the Solo Session Guide**
+- [ ] Understand the five-scene structure
+- [ ] Note the decision points
+- [ ] Prepare opening descriptions
+- [ ] Know how fronts advance scene to scene
+
+---
+
+### During Play:
+
+**Use the Pregen Sheet** for:
+- [ ] Rolling dice (stats + 4dF)
+- [ ] Taking stress (mark boxes)
+- [ ] Invoking aspects (spend Fate points)
+- [ ] Using talents and the Stream move (apply effects)
+- [ ] Tracking consequences
+
+**Reference the Relationship Map** for:
+- [ ] Who to contact in crisis
+- [ ] What NPCs want
+- [ ] Where pressure comes from
+- [ ] How connections complicate choices
+
+**Advance Fronts** when:
+- [ ] Scenes conclude
+- [ ] Time passes
+- [ ] PC choices trigger advancement
+- [ ] Pressure needs escalation
+
+**Invoke Phase Trio** for:
+- [ ] Sponsor or crew cooperation scenes
+- [ ] Flashbacks to the vault dive that started everything
+- [ ] Leveraging Kest's established silence
+- [ ] Complicating the current dive
+
+---
+
+### After Play:
+
+**Update the Pregen Sheet**:
+- [ ] Clear mild consequences (if the scene passed)
+- [ ] Adjust stress tracks if chrome changed
+- [ ] Record new consequences taken
+- [ ] Track Fate point refresh (never less than 3 at session start)
+
+**Evolve the Relationship Map**:
+- [ ] Add new NPCs encountered
+- [ ] Update relationship lines (trust shifts)
+- [ ] Note new leverage gained or lost
+- [ ] Mark which followers stopped being a number and became a name
+
+**Track Front Progress**:
+- [ ] Record which fronts advanced
+- [ ] Note the current step for each
+- [ ] Assess which threatens most next session
+- [ ] Prepare consequences if a clock completes
+
+**Develop Phase Trio Connections**:
+- [ ] Add detail to Kest, Reyes, or Mara
+- [ ] Note how shared history influenced play
+- [ ] Plant seeds for future complications
+- [ ] Deepen or complicate trust
+
+---
+
+## QUICK TROUBLESHOOTING
+
+**"I don't know what Undertow would do"**
+→ Look at her aspects (HIGH CONCEPT, TROUBLE)
+→ Is she performing for the camera right now, or off it?
+→ What does the relationship map show about who's watching?
+
+**"This scene feels flat"**
+→ Check fronts - which one can advance?
+→ Apply pressure from the relationship map
+→ Invoke or compel the Kest connection
+→ Put Meridian's brand-safety interests and Kest's standing order in conflict on the same dive — that collision is built into the character
+
+**"I lost track of NPCs"**
+→ The relationship map shows who exists
+→ Pick one under-used connection
+→ Have them want something from Undertow
+→ Create tension
+
+**"Fronts feel overwhelming"**
+→ Focus on one per session
+→ Advance others slowly in the background
+→ Remember: the PC can slow or stop fronts
+→ Pressure creates drama, not punishment
+
+**"The Kest connection feels unused"**
+→ Have Kest need something faster than Reiko can safely deliver
+→ Compel the standing order at an inconvenient time
+→ Let Kest call in a favor from the vault dive
+→ Build on established silence or established trust
+
+---
+
+## THE PLAY PATTERN
+
+**Every session should touch**:
+1. **Pregen Sheet** (roll dice, use abilities)
+2. **Relationship Map** (interact with someone who matters)
+3. **Fronts** (at least one advances)
+4. **Phase Trio** (reference the history that built the aspects)
+
+**When all four are active**:
+- Mechanics support story
+- Relationships create drama
+- Pressure builds naturally
+- History enriches the present
+
+**This is the integration.**
+
+---
+
+## FINAL NOTES
+
+**These tools serve the story.** If something doesn't work at your table, change it. The goal is **interesting play**, not perfect system adherence.
+
+**Reiko Alvarez is yours now.** The artifacts provide a framework, but you decide:
+- Which frame is real
+- Which relationships matter most
+- Which fronts threaten worst
+- How her story ends
+
+**The system supports**:
+- Ron Edwards' relationship-driven drama
+- Apocalypse World's pressure and momentum
+- FATE's aspect-based storytelling
+- Cyberpunk's total-surveillance paranoia, played from the side of the camera that's supposed to be safe
+
+**Together, they create**: A character ready to perform, smuggle, survive, and find out how long competence can cover for the one thing she can't afford anyone to see.
+
+---
+
+*"You have the pregen sheet. You have the relationships. You have the threats. You have the history. You have the session structure. Now you have everything you need to play Undertow."*
+
+**READY TO START**

--- a/build/docs-v2/influencer_relationship_map.md
+++ b/build/docs-v2/influencer_relationship_map.md
@@ -1,0 +1,237 @@
+# UNDERTOW'S RELATIONSHIP MAP
+## Using Ron Edwards' Relationship Mapping
+
+*A relationship map isn't a follower count. It's who wants what from Reiko, who has leverage over her, and which of those people are one bad frame away from finding out what she's really doing. Every line is a way the algorithm — or a person — could out her.*
+
+---
+
+## WHAT IS A RELATIONSHIP MAP?
+
+Ron Edwards' relationship maps show:
+- **Who wants what from whom**
+- **Who has leverage over whom**
+- **Where loyalties conflict**
+- **What happens when you pressure one connection**
+
+**Not shown**: Sponsor org charts, platform hierarchies, contract terms (those are paperwork, not relationships)
+**Shown**: Trust, debt, obsession, protection, exploitation, parasocial attachment, betrayal
+
+**Each key relationship below is keyed to one of Undertow's three Aspects** — that's what makes it worth drawing. Pressure the relationship, and you're pressuring the Aspect it's built on.
+
+---
+
+## UNDERTOW'S CORE RELATIONSHIP MAP
+
+```
+                              [THE FEED]
+                          (optimizes / exposes)
+                                  |
+                        UNDERTOW (Reiko Alvarez)
+                       /          |           \
+               (streams to)  (funded by)   (smuggles for)
+                     /            |              \
+             FOLLOWERS      MERIDIAN            KEST  ←--(reports to)--→ [KEST'S CLIENT]
+             (1.3M+)        HOLDINGS              |
+              /  |  \            |          (cut in, cautiously)
+             /   |   \      (reviewed by)         |
+      REEFRAT LOGLINE SUBLINE   |              MARA SUND
+    (superfan)(skeptic)(insider) |             (the Producer)
+                  \          DARA REYES              |
+                   \      (brand safety)      (holds the masters)
+                    \___________________________/
+                        (both want the same footage,
+                           for opposite reasons)
+```
+
+---
+
+## KEY RELATIONSHIPS (Detailed)
+
+### UNDERTOW ←→ KEST
+
+**Type**: Standing arrangement, buyer and supplier who never call it that
+
+**Keys**: CONNECTION — *"Kest Turned My Viral Moment Into a Standing Order"*
+
+**What Undertow Wants**: For Kest to keep paying, keep being satisfied with "the streaming version," and never once show up on camera
+**What Kest Wants**: Whatever's actually in the wreck, delivered clean, with Undertow's fame doing the work of getting access nobody would give a plain smuggler
+**Tension**: Kest has never explained who they work for. Undertow has never asked. That silence is the whole relationship
+**Leverage**: Kest holds the unedited vault footage — proof, if they ever want it to be. Undertow has the one thing Kest can't get without her: a legitimate reason to be inside sealed pre-Rise architecture on camera
+**Drama Potential**: What if Kest's tips stop being tips and start being orders with a timeline? What if Kest's client wants to skip Kest and go straight to the source?
+
+**Questions for Play**:
+- How does Kest actually contact Undertow — sponsor-tip DM, dead drop, something dressed up as fan mail?
+- Has Kest ever seen Undertow fail to deliver? What happened?
+- What would Undertow do if Kest asked for something that couldn't be explained on stream at all?
+
+---
+
+### UNDERTOW ←→ MERIDIAN HOLDINGS / DARA REYES
+
+**Type**: Sponsor and the person whose job is to protect the sponsor from her
+
+**Keys**: HIGH CONCEPT — *"Salvage Streamer Smuggling in Plain Sight of Millions"*
+
+**What Undertow Wants**: Sponsorship money, legitimacy, and the corporate cover of "this is a partnership, not surveillance"
+**What Dara Reyes Wants**: Zero brand-safety incidents, a clean quarterly review, and to never have to explain to her own boss why she cleared a dive she shouldn't have
+**Tension**: Reyes doesn't suspect Undertow of smuggling. She suspects Undertow of something — the numbers on every dive are just slightly too good, too consistent, for someone "improvising"
+**Leverage**: Meridian owns the sponsorship, the platform push, and could pull funding tomorrow. Undertow has three years of Meridian's own decommissioning surveys, and knows exactly which ones lied about what was still inside
+**Drama Potential**: What if Reyes's review flags the wrong four seconds for the right reason? What if Meridian's interest in "protecting the brand" and Kest's interest in "protecting the arrangement" want two completely incompatible dives?
+
+**Questions for Play**:
+- What did Meridian's automation actually cost Reiko, materially, before the sponsorship offer arrived?
+- Has Reyes ever cleared a dive she had doubts about? Why?
+- What's the smallest thing that would make Reyes request the raw masters instead of the edited cut?
+
+---
+
+### UNDERTOW ←→ MARA SUND (THE PRODUCER)
+
+**Type**: The one person who edits the version everyone else sees
+
+**Keys**: HIGH CONCEPT + TROUBLE — the gap between the footage and the frame
+
+**What Undertow Wants**: A cut that reads as effortless and complete, with the one missing item simply never having existed
+**What Mara Wants**: To keep being good at a job that increasingly requires not asking questions she already knows the answers to
+**Tension**: Mara has never been told what's happening. Mara has re-cut around the same ninety seconds enough times to know exactly what's happening
+**Leverage**: Mara holds every uncut master file — the only copy of the whole truth that exists anywhere, entirely outside Undertow's control. Undertow is the only income Mara has that doesn't come with someone else's name on the contract
+**Drama Potential**: What happens the day Mara says the sentence out loud instead of just cutting around it? What if someone offers Mara money for the masters instead of asking Undertow?
+
+---
+
+### UNDERTOW ←→ THE FEED
+
+**Type**: Hunter and prey — but the Feed doesn't know it's hunting anything, it's just optimizing
+
+**Keys**: TROUBLE — *"The Footage Doesn't Lie—Except When It Has To"*
+
+**What Undertow Wants**: The Feed to keep pushing her dives to new viewers without ever pushing the wrong four seconds to the right viewer
+**What The Feed Wants**: Whatever gets rewatched. It doesn't care why something gets rewatched — controversy and craftsmanship read identically to an optimization engine
+**Tension**: The Feed rewards anomaly. Undertow's entire business is staying anomalous enough to trend and consistent enough that nobody looks closely. Those two goals fight each other every single dive
+**Leverage**: Neither side has leverage over the other, which is exactly the problem — nobody's driving. Undertow's own Content Vault archive is Feed-searchable, timestamped, and permanent
+**Drama Potential**: What happens when a reaction-stitcher's breakdown video outperforms Undertow's original? What if the Feed decides *that's* the content worth boosting?
+
+---
+
+### UNDERTOW ←→ THE FOLLOWERS
+
+**Type**: 1.3 million people who think they know her, three of whom actually might
+
+**Keys**: HIGH CONCEPT + TROUBLE
+
+**What Undertow Wants**: Loyalty, engagement, and for nobody in that number to look too closely at any single dive
+**What The Followers Want**: Varies wildly — see below
+**Tension**: The parasocial bond is real on both sides. Undertow is genuinely grateful for people who barely know her. That gratitude doesn't make the risk go away
+
+**Named Followers**:
+- **REEFRAT** — Day-one superfan, fiercely loyal, moderates Undertow's chat for free, defends her against anyone who criticizes a dive. *Liability*: will escalate any accusation into a public fight, dragging more eyes to exactly what shouldn't be examined
+- **LOGLINE** — Methodical, patient, not hostile — just correct. Has been quietly cross-referencing dive timestamps against public wreck surveys for months, for the sheer puzzle of it. *Threat*: doesn't yet know what they're building, but they're close
+- **SUBLINE** — Technically expert, oddly precise corrections in chat, offers to "consult" on future dives. Unknown to Reiko: an ex-Meridian salvage surveyor, laid off in the same automation wave that created Undertow. *Opportunity or threat, depending on what they want*: could recognize the survey fraud instantly, and could be an ally, a blackmailer, or a competitor for the same thing Kest wants
+
+**Drama Potential**: What happens when Logline's document and Subline's expertise find each other? What does Reefrat do with either of them?
+
+---
+
+### UNDERTOW ←→ HERSELF (REIKO)
+
+**Type**: The gap between the person diving and the persona streaming it
+
+**Keys**: TROUBLE + HIGH CONCEPT
+
+**What Reiko Wants**: To be good at something in front of people who see it, on her own terms, the way she couldn't be at Meridian
+**What Undertow (the brand) Wants**: Growth, consistency, the next viral dive
+**Tension**: Reiko started this to prove she didn't need anyone owning her work. She now has two employers instead of one, and only one of them signs contracts
+**Drama Potential**: What's the first dive where Reiko can't tell if she's excited about the wreck or performing being excited about it? What does she do the day the two feelings stop being separable at all?
+
+---
+
+## SECONDARY RELATIONSHIPS (To Develop)
+
+### FUTURE CREW CONNECTIONS
+
+Once Phase Four relationships with other PCs are established, add them here:
+
+**Undertow ←→ [NOMAD]**: The unused Crossing option — a boat captain who runs the unlisted route and never asks what's in the bags. Bring this in if the crew includes a Nomad; it's the arrangement Undertow never quite needed until now.
+**Undertow ←→ Infiltrator/Fixer PC**: Sold them footage? Bought their silence? Recognized their work in one of her own dive sites?
+**Undertow ←→ Rigger/Tech PC**: Fixed her Streaming Suite mid-dive? Knows exactly how her Content Vault archive is structured — and searchable?
+
+### NAMES TO DEVELOP
+- **[KEST'S CLIENT]**: Whoever Kest actually works for. Unknown by design — the mystery is the hook
+- **Meridian Legal**: The name attached to the first NDA clause that mentions "content irregularities"
+- **A Rival Streamer**: Competing for the same wrecks, the same sponsors, or the same followers — could expose Undertow accidentally, or on purpose
+- **Corporate Counterintel Analog**: Whoever eventually notices a pattern across multiple "unlisted route" boat trips
+
+---
+
+## HOW TO USE THIS MAP IN PLAY
+
+### For Solo Prequel:
+**Choose pressure points**: GM picks one relationship and applies pressure
+- Reyes requests raw footage for the first time
+- Logline posts the first public question that's a little too specific
+- Kest's tip asks for something on a dive Meridian already has sponsors watching
+- The Feed pushes a stitcher's breakdown above Undertow's own upload
+
+**Escalate connections**: Each session, one relationship gets more complicated
+- Trust deepens or breaks
+- Someone learns something they shouldn't
+- A relationship that was background becomes foreground
+
+### For Crew Play:
+**Add crew to the map**: Where does their orbit cross Undertow's existing relationships?
+**Create triangles**: Undertow + Crew Member + Kest = drama
+**Exploit tensions**: What if the crew needs a dive site Undertow already has a standing order against?
+
+---
+
+## RELATIONSHIP MAP AS PREP
+
+### Before Each Session, Ask:
+1. **Which relationship is under most pressure?** (That's your opening scene)
+2. **What does each NPC want from Undertow this session?** (Immediate goals)
+3. **Which relationship could explode publicly — on camera?** (That's your climax)
+4. **Which relationship could deepen?** (That's character development)
+
+### During Play, Track:
+- **Trust shifts**: When someone's loyalty changes, mark it
+- **New information**: When revealed, draw the new connection line
+- **Leverage gained/lost**: Update who's holding what over whom
+- **Followers who stop being a number**: The moment a name in chat becomes a person with a stake
+
+---
+
+## EXAMPLE PRESSURE SEQUENCES
+
+### SEQUENCE 1: Reyes Starts Asking
+Session 1: Dara Reyes requests raw footage for "routine" quarterly review
+Session 2: Reyes asks Mara Sund directly about a specific timestamp
+Session 3: Reyes requests the uncut masters, bypassing Mara entirely
+**Resolution**: Stall Meridian, sacrifice the sponsorship, or find out what Reyes actually suspects
+
+### SEQUENCE 2: Logline Builds the Case
+Session 1: Logline posts a benign technical question in chat
+Session 2: Subline answers it with suspiciously precise detail
+Session 3: Logline publishes a partial video essay — "Things That Don't Add Up"
+**Resolution**: Recruit Subline, discredit Logline, or let the thread go public and deal with the fallout live
+
+### SEQUENCE 3: Kest Changes the Terms
+Session 1: Kest's tip names an exact bulkhead and container — no more plausible deniability
+Session 2: Kest asks Undertow to bring Mara into the arrangement
+Session 3: [KEST'S CLIENT] contacts Undertow directly, bypassing Kest for the first time
+**Resolution**: Burn the arrangement on her own terms, or find out exactly who's been paying for the vault all along
+
+---
+
+## KEY PRINCIPLE
+
+**Relationship maps are dynamic.** Every session changes them. Every choice Undertow makes on stream strengthens some connections and weakens others. Every follower who notices something adds a new line. The map at session five should look nothing like the map at session one.
+
+**Relationships drive story.** When you're unsure what happens next, look at the map. Pick a relationship under tension. Apply pressure. Watch what breaks — or what goes viral.
+
+**NPCs want things, and some of them are watching closely.** Kest doesn't wait for a call. Reyes doesn't wait for a confession. Followers don't wait for permission to start a thread. That's where play happens.
+
+---
+
+*"You're not infiltrating a building. You're broadcasting into a web of people who are already watching — sponsors, followers, a fixer who's never once shown his face. Every person on this map has a camera pointed somewhere. The question is whether it's pointed at you yet."*
+
+**USE THIS MAP TO GENERATE DRAMA, NOT TO PLAN OUTCOMES**

--- a/build/docs-v2/influencer_solo_session.md
+++ b/build/docs-v2/influencer_solo_session.md
@@ -243,7 +243,7 @@ woman dive
 **If Corporate Answers**:
 - Roll Cool
 - Success: Reyes is satisfied, for now. **The Review Cycle** does not advance this scene
-- Failure: Too smooth. Reyes doesn't call it out, but she requests a follow-up meeting — advance **The Review Cycle** to step 2
+- Failure: Too smooth. Reyes doesn't call it out, but she requests a follow-up meeting — advance **The Review Cycle** by 1
 
 **If Redirect Through Mara**:
 - No roll — but this pulls Mara further into the exposure than she's ever been pulled before
@@ -255,7 +255,7 @@ woman dive
 - Roll Tech to pull the right archived footage fast enough to feel natural in the room
 - Success: Reyes gets a real, honest, satisfying answer to a real question — just not the one underneath it. **The Review Cycle** does not advance
 - Success with style: Reyes is impressed enough to say so out loud. Small trust gained — useful leverage later
-- Failure: The search takes visibly too long for something that should be instant. Reyes notices the hesitation more than the content. Advance **The Review Cycle** to step 2
+- Failure: The search takes visibly too long for something that should be instant. Reyes notices the hesitation more than the content. Advance **The Review Cycle** by 1
 
 **If Sit With It**:
 - No roll for Reyes — this branch is about Reiko, not the review

--- a/build/docs-v2/influencer_solo_session.md
+++ b/build/docs-v2/influencer_solo_session.md
@@ -1,0 +1,465 @@
+# SOLO PREQUEL SESSION: UNDERTOW GOES LIVE
+## Running an Evening's Play for Reiko Alvarez's Origin
+
+*This session establishes Undertow as a character before crew play begins. It develops her relationships, tests her cover, and sets fronts in motion. By the end, you'll know who's really diving down there — and what's watching her do it.*
+
+**Duration**: 2-3 hours
+**Structure**: 4-5 scenes with breathing room between
+**Goal**: Establish character, relationships, and active threats
+
+---
+
+## SESSION SETUP
+
+### Before Play Begins
+
+**Review the Character Sheet**: Make sure you understand Reiko's three frames (see the pregen sheet, "THE FRAME"):
+- What Meridian Sees (compliant content partner, worth the sponsorship line item)
+- What 1.3 Million Followers See (Undertow — fast, funny, fearless)
+- What Only Kest Knows (one item per haul isn't hers to keep)
+
+These aren't three identities the way an Infiltrator runs three IDs — it's one person, one face, three audiences who each believe they're seeing the true one. That gap is where this session lives.
+
+**Confirm the Crossing**: Reiko's Connection is Kest (Phase Trio, Option B — *"Kest Turned My Viral Moment Into a Standing Order"*). Mara Sund, her producer, is a secondary NPC regardless of that choice — she's the one who cuts the footage, every session, whether or not she's ever named on camera. The Nomad Crossing was never taken; it stays parked for Phase Four, in case a Nomad PC joins the crew later.
+
+**Establish Starting Position**:
+- Status: Two viral dives in. Sponsorship growing. Kest's tips still framed as coincidence, not orders.
+- Current Objective: Keep three audiences fed without any of them comparing notes.
+
+**Set Front Positions** (from the Fronts document):
+- **The Feed Finds Its Own Story**: Step 1 (nothing pushed yet, but the vault dive is out there)
+- **The Review Cycle**: Step 1 (Reyes's process is still routine — for now)
+- **The Skeptic's Thread**: Step 1 (Logline hasn't posted anything yet)
+- **Kest's Standing Order**: Step 1 (tips are still framed as "fan mail")
+
+---
+
+## SCENE ONE: THE LIVE DIVE
+
+**Frame**: Late morning, a sealed pre-Rise maintenance level, sixty feet down, stream live
+
+**Setup**: Kest's latest tip arrived three days ago, dressed up as a fan message: *coordinates, a bulkhead number, "you'll want to see what's behind this one."* Meridian's PR calendar independently flagged the same wreck as this month's featured dive — nobody planned that collision, it just happened, the way Front #2 and Front #4 were always going to want the same footage eventually. Forty thousand people are watching live right now, and the number's still climbing. Somewhere in this sealed level is a container Kest wants, and it is not the thing Reiko is supposed to be looking for on camera.
+
+**Objectives**:
+- Get to Kest's target and out of frame with it, without a shot of it existing
+- Keep the dive reading as spontaneous and thrilling — Meridian's watching the numbers too
+- Decide whether to spend this session's one use of **The Stream** here, or save it
+
+---
+
+### Opening Description
+
+*Multi-cam feed cuts between your helmet view and the two drone cams trailing you. Chat is a wall of scrolling text you're not reading but can feel. The door in front of you is exactly what Kest's tip promised — sealed, corporate-era, the kind of lock that makes for good television when you crack it. Behind it, according to the tip: "second locker left of the intake valve." You haven't looked yet. You don't know what's actually in there. You never do until you're already holding it.*
+
+*"Alright," you say to camera, easy, unbothered, "let's see what eleven years of seawater does to a corporate vault door."*
+
+**What do you do?**
+
+---
+
+### What's Really Happening
+
+**CHALLENGE**: Crack the door on camera, then retrieve Kest's item out of frame, without breaking the "effortless" performance
+**RISK**: A sloppy palm reads as suspicious to anyone reviewing frame-by-frame later — feeds Front #1 or Front #2 down the line
+**OPPORTUNITY**: A spectacular, *legitimate* find on the same dive gives Meridian something real to be happy about, buying slack with Reyes
+
+**Possible Approaches**:
+1. **Thread the Needle** (Tech): Crack the door for the camera, use the drone's blind spot to palm the item clean
+2. **Cut the Feed Early** (Cool): Stage a "signal dropout" — bad water, bad luck — and go dark for the ninety seconds that matter
+3. **Spend The Stream** (Cool): Lean all the way into "everyone's watching," turn the whole retrieval into a performed moment with nowhere to hide — riskier, but if it lands, it's the biggest number of the day
+4. **Split Take** (Tech + Cool at -1): Try to deliver spectacle *and* a clean palm in the same ninety seconds
+
+---
+
+### GM Moves Based on Player Choice
+
+**If Thread the Needle**:
+- Roll Tech
+- Success: Item's gone, nobody the wiser, dive continues clean
+- Success with style: The door-crack itself is good enough content that Meridian's clip team flags it for a promo — real goodwill banked
+- Failure: Item retrieved, but a drone catches half a frame of it. Doesn't get flagged today. Advance **The Feed** to step 2 (a stitcher will find that frame eventually)
+- Critical failure: The half-second hitch in your movement reads on camera as "off." Chat notices something's weird before Reiko does. Advance **The Skeptic's Thread** to step 2
+
+**If Cut the Feed Early**:
+- No roll for the retrieval — it's clean by default
+- But a genuine gap in a "raw and unedited" stream is exactly the kind of thing sponsor analytics flag
+- Advance **The Review Cycle** by 1 (a genuine gap is a routine-tightening beat, brought forward — pressure builds toward Reyes requesting raw footage)
+- Chat speculates about the dropout; Reefrat defends her in the comments before anyone even asks a real question
+
+**If Spend The Stream**:
+- The Stream is active: +2 Cool, evidence exists of everything, no backing down
+- Roll Cool for the retrieval itself, now performed in full view of the drones instead of hidden from them
+- Success with style: Somehow it reads as pure showmanship — sleight of hand as content. Gain a Fate point per The Stream's normal resolution
+- Failure: It's on tape. Not obviously wrong yet — but it's there, permanently, in the one place with the least plausible deniability. Advance **The Feed** to step 3 directly (this frame is now searchable, high-engagement, and real)
+
+**If Split Take**:
+- Roll Tech and Cool, both at -1
+- Both succeed: Rare clean win — spectacular *and* invisible. Advance nothing negative this scene
+- One succeeds: Mixed outcome — GM picks which half worked, other half creates a minor loose thread (advance one front by 1, GM's choice of which)
+- Both fail: Bad dive. Item recovered late, sloppily, on camera. Advance **The Review Cycle** and **The Feed** each by 1
+
+---
+
+### Scene Resolution
+
+**End with**: The dive wraps. Numbers are good — not viral-good, but solid. Kest's item is wherever Kest's items go. Reiko surfaces, pulls the mask, grins for the topside camera. *"That's the dive, folks. See you next time."* Chat is already asking when the next one drops.
+
+**Advance**: At minimum, **Kest's Standing Order** to step 2 — the tip got more specific this time, and it worked. Additional advancement per the branch taken above.
+
+**Stress Check**: If the retrieval was tense, 1-2 Systems stress from the physical strain of working two jobs in one dive window.
+
+---
+
+## SCENE TWO: THE COMMENT SECTION
+
+**Frame**: That evening, reviewing the stream's live chat replay from her apartment
+
+**Setup**: Every dive gets picked apart in the comments afterward — normally harmless. Tonight, scrolling through the replay chat, Reiko finds a question from a handle she half-recognizes: **Logline**, asking, politely, technically, why the depth reading on today's dive doesn't quite match the public wreck survey for that tower. It's not an accusation. It's just correct. And underneath it, a reply from another regular — **Subline** — with a correction so precise it reads like someone who's actually done this kind of survey work.
+
+**Objectives**:
+- Decide how — or whether — to respond to Logline in the moment
+- Figure out what Subline actually knows, without confirming anything by asking
+- Keep Reefrat, who's already spoiling for a fight in the replies, from making this bigger than it is
+
+---
+
+### Opening Description
+
+*Chat replay is a wall of scroll, mostly noise — "SO GOOD," "the SOUND design on that door," a dozen sponsor-tag mentions. Then this, timestamped eleven minutes into the dive:*
+
+```
+LOGLINE: quick q — the depth reading at 3:47 doesn't match the public
+survey for this tower (survey says -14m more). anyone know why?
+not a complaint, just curious
+
+SUBLINE: survey depths for pre-Rise towers in that sector were
+revised twice after decommission — first cut was rushed. wouldn't
+trust the public number over her instruments tbh
+
+REEFRAT: why are people always trying to catch her out lol let the
+woman dive
+```
+
+*Logline isn't wrong. Logline is never wrong, as it turns out — you just haven't met them yet. And Subline's correction isn't a guess. That's the kind of correction you make when you used to write the surveys.*
+
+**What do you do?**
+
+---
+
+### What's Really Happening
+
+**CHALLENGE**: Respond to a benign, correct question without confirming there's anything to find
+**RISK**: Handled wrong, this is the first thread that doesn't unravel — it's the first thread that gets *pulled on*
+**OPPORTUNITY**: Subline sounds like someone who could be useful, if Reiko ever needs an ally who already half-knows
+
+**Possible Approaches**:
+1. **Deflect in Character** (Cool): Reply live, breezy, on-brand — "instruments don't lie, survey's outdated, thanks for the nerd-check" — technically true, closes the thread
+2. **Read the Room** (Cool, per the front's custom move): Study Logline and Subline's posting history before responding — ask the GM one question about what they've actually got
+3. **DM Subline Directly** (Cool + Nerves risk): Reach out privately, try to find out how much Subline actually knows, and why
+4. **Say Nothing** (no roll): Let Reefrat run interference and hope the thread dies of its own accord
+
+---
+
+### GM Moves Based on Player Choice
+
+**If Deflect in Character**:
+- Roll Cool
+- Success: Thread closes, reads as normal chat texture. **The Skeptic's Thread** does not advance this scene
+- Failure: Deflection is a little too smooth, a little too fast. Logline doesn't say anything else tonight — but files it
+- Either way, advance **The Skeptic's Thread** to step 2 at the *start* of the next session unless directly addressed again
+
+**If Read the Room**:
+- Roll Cool
+- Success: Ask one question — *"How much does Logline actually have?"* or *"What does Subline actually want?"* GM answers honestly
+- Success with style: Ask both
+- Failure: Whatever Reiko learns is wrong, or incomplete — acting on it later creates its own problem
+
+**If DM Subline Directly**:
+- No roll to send the message — but this is the first time Reiko has ever reached toward one of the 1.3 million on purpose
+- Advance **The Skeptic's Thread** to step 2 immediately (a private message is still a data point, and it's a live wire now, not background noise)
+- In exchange: Subline reveals, unprompted, that they used to write decommissioning surveys for Meridian — the same division Reiko used to work for, before the automation wave. Neither of them says the rest of the sentence out loud
+
+**If Say Nothing**:
+- No roll
+- Reefrat handles it — loudly, protectively, dragging more eyes to the exchange than it would've gotten on its own
+- Advance **The Skeptic's Thread** to step 2 regardless (Reefrat's defense is now part of the record too)
+
+---
+
+### Scene Resolution
+
+**End with**: Whatever Reiko does, Logline's question stays answered but not resolved — it's the kind of thing that gets asked again, differently, once there's a pattern instead of one data point. Subline logs off without confirming or denying anything. Reefrat is still typing.
+
+**Advance**: **The Skeptic's Thread** to step 2 (per branch above)
+
+**Stress Check**: 0-1 Nerves — this scene is quiet pressure, not danger. The unease is in noticing how easily someone could build a case, not in anything happening yet.
+
+---
+
+## SCENE THREE: THE VAULT FOOTAGE
+
+**Frame**: Two days later, a booth in Meridian's brand-safety office, mid-afternoon
+
+**Setup**: Dara Reyes's quarterly review has, for the first time, requested raw footage instead of the edited cut — "standard update to process," her email said, and it might even be true. Reiko has to sit in the review booth with Reyes and Mara Sund and watch her own unedited vault dive — the one that made her — frame by frame, Reyes narrating exactly what she's looking for. Reiko's Content Vault talent means the footage exists in perfect, searchable fidelity. That's exactly the problem.
+
+**Objectives**:
+- Get through the review without Reyes requesting the *one* clip that matters
+- Read what Reyes actually suspects versus what she's saying
+- Sit with her own highlight reel and figure out, honestly, which parts were the job and which parts were the performance — because right now she can't tell either
+
+---
+
+### Opening Description
+
+*The booth is small, corporate-neutral, built for exactly this. Reyes has a tablet and a very calm voice. Mara sits one seat over, saying nothing — her editor's instinct for when to stay quiet fully engaged. On the screen: you, eleven months younger, cracking the vault door for the first time, viewers screaming into chat that you can't hear anymore but can still picture.*
+
+*"Walk me through this sequence," Reyes says, and rewinds four seconds — landing exactly on the frame before the one that matters. "This part reads a little rushed for someone your caliber. Anything happening off-camera we should know about?"*
+
+*It's a fair question. It's also the only question that matters. And you have, by talent and by training, perfect recall of exactly what happened in the four seconds after this one.*
+
+**What do you do?**
+
+---
+
+### What's Really Happening
+
+**CHALLENGE**: Answer Reyes's questions about your own footage without either lying badly or confirming anything
+**RISK**: Reyes isn't accusing you of smuggling — she's accusing the *numbers* of being too good, too consistent, for someone "improvising." She's closer than she knows.
+**THREAT**: Reiko's Content Vault talent isn't in play as a resource yet — it's just true. There's no footage she doesn't have perfect recall of, including the parts she'd rather not remember that clearly
+**OPPORTUNITY**: Handled well, this could actually deepen trust with Reyes — or with Mara, who already knows more than she's ever said
+
+**Possible Approaches**:
+1. **Corporate Answers** (Cool): Play it exactly the way Reyes expects — technical, confident, nothing extra
+2. **Redirect Through Mara** (Cool): Let Mara answer the editorial questions, protecting the moment where the cut actually happened
+3. **Use Content Vault** (as written on the sheet): Spend the talent's once-per-session use here — pull up a *different* piece of the archive that answers Reyes's real question ("was this rushed?") with something true and unrelated, burying the real four seconds under a mountain of real ones
+4. **Sit With It** (Cool + Nerves stress, no deflection): Actually watch the footage straight through, let herself feel what's real and what's performed, and answer Reyes as honestly as she can without naming the thing itself
+
+---
+
+### GM Moves Based on Player Approach
+
+**Track two things this scene**: how much suspicion Reyes leaves the booth with (**The Review Cycle**), and how much Reiko learns about her own gap between performing excitement and feeling it (**Trouble** aspect gets hot either way)
+
+**If Corporate Answers**:
+- Roll Cool
+- Success: Reyes is satisfied, for now. **The Review Cycle** does not advance this scene
+- Failure: Too smooth. Reyes doesn't call it out, but she requests a follow-up meeting — advance **The Review Cycle** to step 2
+
+**If Redirect Through Mara**:
+- No roll — but this pulls Mara further into the exposure than she's ever been pulled before
+- Advance **The Review Cycle** to step 3 regardless ("needs producer commentary before clearing" — a first)
+- Mara answers carefully, protecting Reiko without ever being told to. Note this: it's the first time Mara has actively covered rather than just quietly not-asking
+
+**If Use Content Vault**:
+- Spend the once-per-session talent use
+- Roll Tech to pull the right archived footage fast enough to feel natural in the room
+- Success: Reyes gets a real, honest, satisfying answer to a real question — just not the one underneath it. **The Review Cycle** does not advance
+- Success with style: Reyes is impressed enough to say so out loud. Small trust gained — useful leverage later
+- Failure: The search takes visibly too long for something that should be instant. Reyes notices the hesitation more than the content. Advance **The Review Cycle** to step 2
+
+**If Sit With It**:
+- No roll for Reyes — this branch is about Reiko, not the review
+- Take 2 Nerves stress (the actual cost of watching yourself that closely and not being sure what you're looking at)
+- Reyes gets a real, human, slightly-too-honest answer about pacing and instinct — reads as authentic, satisfies her for now
+- **The Review Cycle** does not advance
+- But the Trouble aspect is now explicitly *live* for the rest of the session — the GM should compel it at the next opportunity
+
+---
+
+### Scene Resolution
+
+**End with**: Reyes closes the tablet. "Thanks for your time, Undertow — Reiko. Whichever." Small smile, not unkind, not entirely readable. Mara doesn't meet your eyes on the way out, which is its own kind of answer. Somewhere in that footage, watched frame by frame with a company auditor in the room, was the moment that made you and the moment you're still hiding, and for the length of one meeting they were the same four seconds.
+
+**Advance**: **The Review Cycle** per branch above. Note whether the Trouble aspect is "hot" heading into the next scene.
+
+**Stress Check**: Minimum 1 Nerves, more if Sit With It was chosen. This is the session's identity-pressure scene — treat it accordingly.
+
+---
+
+## SCENE FOUR: KEST'S NEW ASK
+
+**Frame**: Late that night, Reiko's apartment, off-camera for once
+
+**Setup**: A message arrives through the usual channel — dressed as a fan DM, coordinates and a line that reads sweetly to anyone else: *"Loved today's dive!! You should check out [coordinates] next, heard it's incredible down there 💙"* Reiko knows the real message underneath it. This one's bigger than the last one — Kest wants a specific container from a wreck that's already scheduled as next week's *sponsor-attended* dive, cameras from two other brands included, Reyes almost certainly watching live given this week's review.
+
+**Objectives**:
+- Decide whether to take the job, knowing Reyes's attention is already up
+- Figure out whether Kest even knows — or cares — about the review cycle heating up
+- Sit with the fact that saying no to Kest, for the first time, is now a real option and not a rhetorical one
+
+---
+
+### Opening Description
+
+*Your apartment is small and mostly unstyled — everything here is genuinely yours, which after today's meeting feels almost strange. The message sits on your personal deck, not your sponsor-monitored one. You read the coordinates twice. It's the wreck for next Thursday's dive — the one with two sponsor reps on-site, the one Reyes already has flagged for extra scrutiny after today.*
+
+*Kest has never once asked about your schedule. Kest has also never once asked for something this specific, this close to a dive Meridian is already watching hard.*
+
+**What do you do?**
+
+---
+
+### What's Really Happening
+
+**CHALLENGE**: Decide how to respond to an escalating ask under converging pressure
+**RISK**: Taking this job risks doing it on the one dive where Front #2 and Front #4 stop being separate problems and start being the same problem
+**DECISION POINT**: Comply, push back, or try to thread a needle that might not have room left in it
+
+**Possible Approaches**:
+1. **Confirm the Job** (Cool): Message back yes, start planning how to make it work anyway
+2. **Push Back** (Cool + Nerves risk): Tell Kest, for the first time, that this timing doesn't work — and find out how Kest actually reacts to "no"
+3. **Loop In Mara** (Code + Cool): Consider whether bringing Mara fully into the loop — telling her what's actually happening, not just letting her infer it — would make Thursday survivable
+4. **Sit on It** (no roll): Don't answer tonight. Buy a few hours to think, and see what that costs
+
+---
+
+### GM Moves: The Pressure Read
+
+**This scene is about internal pressure**, same as the equivalent beat in any solo prequel — there's no external threat in the room, just the weight of a decision.
+
+**If Confirm the Job**:
+- Roll Cool to gauge just how much riskier this one is than the last
+- Success: Reiko has a real plan, however thin
+- Failure: She's committed before she's actually figured out how
+- Either way: Advance **Kest's Standing Order** to step 4 ("Kest's client changes the ask — something that requires Reiko to actively lie on stream, not just omit") and flag that **The Review Cycle** and **Kest's Standing Order** are now pointed at the *same dive*
+
+**If Push Back**:
+- Roll Cool
+- Success: Kest, for once, actually backs off the timeline — doesn't love it, but takes the delay
+- Failure: Kest's reply is short, colder than usual: *"That's not really how this works."* First real sign of what happens when the arrangement doesn't go Reiko's way
+- Take 1 Nerves stress either way — this is the first time she's said no to Kest, and her body knows it even if the message reads calm
+
+**If Loop In Mara**:
+- Roll Code + Cool (finding the right way to say it, and reading how Mara actually takes it)
+- Success: Mara doesn't flinch — turns out she'd already put most of it together. One more person now genuinely inside the arrangement, for better or worse
+- Failure: Mara hears more than Reiko meant to say, and needs time before she says anything back
+- Either way: advance **The Review Cycle** by 1 (Mara is now protecting something she was explicitly told about, not just quietly not-asking — that changes what she's exposed to)
+
+**If Sit on It**:
+- No roll
+- The GM should offer a compel here: *Your Connection is "Kest Turned My Viral Moment Into a Standing Order." Kest doesn't like being made to wait. Take a Fate point if the silence costs you something?*
+- Player's choice whether to accept
+
+---
+
+### Scene Resolution
+
+**End with**: Reiko puts the deck down, message answered or not. Whatever she chose, Thursday is now a dive with at least three separate audiences expecting three separate things from the same sixty minutes underwater — Meridian wants clean, Kest wants productive, and 1.3 million people just want it to be good television. She's the only person who has to deliver all three.
+
+**Advance**: **Kest's Standing Order** per branch above. Note the front intersection: **The Review Cycle + Kest's Standing Order** are now converging on the same future dive.
+
+**Stress**: 1-2 Nerves depending on how the confrontation (or avoidance) went
+
+**Decision**: Does Reiko go into Thursday's dive planning to do the job, or planning to finally refuse one? (Player chooses; GM accepts either answer — this sets up Scene Five.)
+
+---
+
+## SCENE FIVE: THE CHOICE *(Optional — If Time Allows)*
+
+**Frame**: Thursday, the sponsor-attended dive, live, cameras from three brands rolling
+
+**Setup**: This is the dive Scene Four built toward. Reiko goes in with sponsors watching, Reyes watching closer than usual, and Kest's ask still sitting in her queue. Whatever she chose two scenes ago, this is where it plays out in front of everyone at once.
+
+---
+
+### IF REIKO DOES THE JOB ANYWAY:
+
+**Frame**: Sixty feet down, three sponsor reps topside, Reyes reviewing live instead of after the fact for the first time ever
+
+*The dive goes well — genuinely well, the kind of well that makes for good sponsor footage. You find Kest's target exactly where the tip said it would be. You also notice, mid-retrieval, that one of the sponsor drones has a better angle on you than the others usually do. Not aimed at you on purpose. Just there. Watching. The way everything's always watching.*
+
+*You get the item. You also can't be sure, yet, whether you got away with it.*
+
+**Advance**: **The Review Cycle** to step 3 ("needs producer commentary before clearing" or equivalent, GM's call based on how clean the retrieval read) and **Kest's Standing Order** to step 5 ("the same dive gets claimed by both fronts at once")
+**Opportunity**: The job's done. Kest is satisfied. Meridian has great footage. Nobody's asked the hard question yet — but the margin for the next dive just got thinner
+**Threat**: That sponsor drone footage exists now too, and nobody controls its final cut but Mara
+
+---
+
+### IF REIKO PULLS THE JOB:
+
+**Frame**: Sixty feet down, deciding, live, not to reach for the container Kest wanted
+
+*You get to the bulkhead. You see the container. You also see, on the feed's corner display, that engagement is already strong without it — the door-crack alone is good television. You leave it sealed. Just this once. It feels like nothing happened. It also feels like the first real thing you've decided entirely on your own terms in months.*
+
+*Kest is going to want an explanation. You don't have a good one yet.*
+
+**Advance**: **The Review Cycle** does not advance this scene — the dive reads completely clean. **Kest's Standing Order** advances to step 3 regardless ("Kest misses a scheduled handoff window" becomes, instead, Reiko missing hers — same effect, same tension)
+**Opportunity**: For one dive, all three audiences got exactly what they were told they were getting. That's never happened before.
+**Threat**: Kest doesn't do disappointment quietly for long. The standing order was never actually optional, and Reiko just found out what happens when she treats it like it was.
+
+---
+
+## SESSION CONCLUSION
+
+### Debrief Questions
+
+**Ask the player**:
+1. **Which frame felt most real during play?** (Meridian's content partner, Undertow the brand, or the person Kest actually talks to)
+2. **What surprised you about Reiko's choices?**
+3. **Which relationship matters most right now?** (Kest, Reyes, Mara, or the followers — pick one)
+4. **What do you want to happen next?**
+
+### Establish for Crew Play
+
+**What's true now**:
+- The Content Vault archive is deeper, and Reiko now knows exactly how much it can and can't protect her
+- Reyes is paying closer attention than routine calls for — not accusing, but circling
+- At least one follower (Logline, Subline, or both) is closer to a real pattern than Reiko realizes
+- Kest's arrangement has changed shape — either it's deeper, or it's the first time Reiko's pushed back
+- Mara Sund knows more than she did at the start of the session, one way or another
+
+**Advance Fronts** *(totals will vary by choices made — use this as a template)*:
+- **The Feed**: Step 1-3 (quiet promotion, maybe a flagged frame)
+- **The Review Cycle**: Step 1-3 (routine tightening, possibly converging with Kest's order)
+- **The Skeptic's Thread**: Step 2 (Logline's question is now on record either way)
+- **Kest's Standing Order**: Step 2-5 (the biggest mover this session, especially if Scene Five ran)
+
+**Consequences Taken**: Record any stress, consequences, or burned Fate points
+
+### Relationship Status
+
+**By the end of solo session, establish**:
+- Status with Kest (satisfied? testing her? recalibrating after a first "no"?)
+- Status with Dara Reyes (routine suspicion? something more specific now?)
+- Status with Mara Sund (still just not-asking? actively covering? somewhere new?)
+- Status with the followers (Logline still just curious? Subline revealed anything more? Reefrat still just loud?)
+
+**These relationships carry forward into crew play.**
+
+---
+
+## GM NOTES: RUNNING SOLO SESSIONS
+
+### Pacing:
+- **Scene 1**: Establish the routine and the risk inside it (35 min)
+- **Scene 2**: Raise the audience-as-threat question (25 min)
+- **Scene 3**: Existential pressure — performance vs. self (35 min)
+- **Scene 4**: Escalate the standing order (25 min)
+- **Scene 5** *(optional)*: Force the choice (30 min)
+- **Debrief**: (10 min)
+
+**Total**: 2.5 hours comfortably, 3 hours with good roleplay and Scene Five included
+
+### Tone:
+**Not grimdark.** Not a heist thriller either. Reiko is competent, funny on camera, genuinely good at the work. The pressure is real but it's corporate-absurd as often as it's dangerous — brand-safety audits, algorithm behavior, comment-section detective work. Gene Wolfe + Jack Vance filtered through a livestream: weird, elegant, human, occasionally very funny in a way that doesn't undercut the stakes.
+
+### Key Themes:
+- **Visibility**: What does it cost to be unmissable on purpose?
+- **Performance vs. authenticity**: Can she still tell her own excitement from the performed version?
+- **Indifferent surveillance**: The Feed doesn't hate her. It doesn't have to, to end her.
+- **The audience as jury**: 1.3 million people are watching. Some of them are paying closer attention than she'd like.
+
+### Success Criteria:
+**By end of session, player should**:
+- Understand all three of Reiko's frames and feel the gap between them
+- Feel pressure from at least two different fronts
+- Care about at least two NPCs (Kest, Reyes, Mara, or one of the three named followers — pick two)
+- Have made at least one significant choice with no clean outcome
+- Be ready to play Undertow with a crew
+
+---
+
+*"Solo sessions aren't about completing missions. They're about discovering who your character is when no one's watching. Except with this one, someone is always watching — that's the whole premise. The question was never whether the cameras catch her. It's whether she can still tell, underneath all of it, which parts were ever really her own."*
+
+**NOW YOU'RE READY TO PLAY UNDERTOW**


### PR DESCRIPTION
## Summary
Adds a complete six-artifact solo-play kit for **The Influencer**, following the same structure as the existing Shodann/Infiltrator kit (`shodann_phase_trio.md`, `shodann_relationship_map.md`, `shodann_fronts.md`, `shodann_solo_session.md`, `shodann_quick_reference.md`) but built from scratch around a deliberately opposite premise: public performance, a parasocial audience, and corporate sponsorship pressure instead of total-secrecy espionage.

**Character**: Reiko Alvarez, streaming as **Undertow** — a salvage-diving streamer whose viral dives each carry a second, unshown payload for a fixer named Kest.

## Changes
Six new files under `build/docs-v2/`:
- `influencer_phase_trio.md` — FATE-style phase generation producing the three Aspects (High Concept, Trouble, Connection), cross-checked against `influencer_playbook_v2.md` and `core_moves_sheet.md`
- `influencer_pregen.md` — full character sheet (aspects, stats, stress, chrome, talents, gear, roleplaying notes), with a rules-check pass documenting exact stress-math verification against the playbook
- `influencer_relationship_map.md` — Ron Edwards-style NPC web (Kest, Meridian/Dara Reyes, Mara Sund the producer, The Feed, and three named followers)
- `influencer_fronts.md` — four Apocalypse World-style threats with 8-10 step countdown clocks, Cast lists drawn directly from the Relationship Map
- `influencer_solo_session.md` — 4-5 scene GM-guided solo session (2-3 hour target)
- `influencer_quick_reference.md` — synthesis doc tying the other five together, plus a prep/play/debrief checklist

## Fixes made in response to product-acceptance review
A review pass against Issue #29's acceptance criteria flagged a few real inconsistencies, fixed directly before this PR:

1. **NPC name collision**: the new brand-safety antagonist was originally named "Dara Voss," colliding with **Kaida Voss**, the playbook's existing canonical worked-example Influencer character (`build/docs-v1/kaida_voss_pregen.md`, `influencer_playbook_v2.md`). Renamed to **Dara Reyes** throughout.
2. **Front starting-position contradiction**: the Quick Reference's "Set Front Starting Positions" checklist described Step 1 as already-completed events (e.g. "raw footage first requested"), while the Solo Session's own Session Setup described the same Step 1 as nothing-has-happened-yet. Reconciled both documents to the same convention, matching the Fronts document's literal step numbering.
3. **Two mismatched front-advancement citations** in the Solo Session (Scene One "Cut the Feed Early" and Scene Four "Loop In Mara") claimed to advance The Review Cycle "to step 2," but the described content didn't match Front #2's actual bullet 2 ("Meridian signs a second sponsor"). Both now use relative "advance by 1" phrasing, consistent with how the same document already expresses soft/ambiguous advancement elsewhere (e.g. the Split Take branch in Scene One).

Not carried forward from the review: the "duplicate solo-session file" and "checklist wording" minor notes were artifacts of the scratchpad/drafting process and don't apply once the six canonical files land in `build/docs-v2/`; the Scene Two double-counted countdown step was left as-is per the review's own assessment that it's low-impact ("GM just ends up at 2 regardless").

## Testing
- [x] Verified formatting renders correctly
- [x] Cross-referenced with related playbooks/content (`influencer_playbook_v2.md`, `core_moves_sheet.md`, `shodann_phase_trio.md` and siblings)
- [x] Checked for consistency with existing materials (NPC naming, stress-track math, aspect text verbatim across all five documents)
- [x] Reviewed for style and tone alignment (distinct from Infiltrator/Shodann's espionage framing per Issue #29's explicit goal)

## Related Issues
Closes #29

## Phase
- [x] Phase 1: Finalize RPG Text

## Review Focus
- Confirm the Dara Reyes rename reads cleanly and doesn't need a different name
- Front step-numbering conventions across `influencer_fronts.md` / `influencer_solo_session.md` / `influencer_quick_reference.md` — flag if any other citations still read oddly
- Whether Mara Sund (the Producer) belongs as a fixed secondary NPC regardless of the Phase Two Crossing choice, versus being folded into the unused Crossing options list

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>